### PR TITLE
Prevent Cmd-W from closing app while OverlayViewController is active

### DIFF
--- a/SheepShaver/src/MacOSX/SheepShaveriOS/Swift/Overlay/OverlayViewController.swift
+++ b/SheepShaver/src/MacOSX/SheepShaveriOS/Swift/Overlay/OverlayViewController.swift
@@ -547,6 +547,14 @@ public class OverlayViewController: UIViewController {
 }
 
 extension OverlayViewController {
+
+	@objc
+	public override func performClose(_ sender: Any?) {
+		// Handle Cmd+W: forward it to the emulated app instead of closing
+		// The emulator will receive the keyboard event normally
+		// We intentionally do nothing here to prevent the app from closing
+	}
+
 	@objc
 	public static func injectOverlayViewController(
 		keyInteraction: @escaping ((Int, Bool) -> Void),


### PR DESCRIPTION
Overrides performClose() while intentionally doing nothing within the overriding method -- Cmd-W keystroke is then passed to the emulator.