### PR TITLE
sierra760/mem-alloc: use bulk memory allocation on iOS to eliminate ASLR launch crashes

### DIFF
--- a/BasiliskII/src/CrossPlatform/vm_alloc.cpp
+++ b/BasiliskII/src/CrossPlatform/vm_alloc.cpp
@@ -217,7 +217,12 @@ int vm_init(void)
 #endif
 
 #ifdef MEM_BULK
-	VMBaseDiff = (vm_uintptr_t)vm_acquire_internal(0x60000000, VM_MAP_DEFAULT);
+	void *bulk = vm_acquire_internal(0x60000000, VM_MAP_DEFAULT);
+	if (bulk == VM_MAP_FAILED) {
+		fprintf(stderr, "vm_init: failed to allocate bulk memory region (0x60000000 bytes)\n");
+		return -1;
+	}
+	VMBaseDiff = (vm_uintptr_t)bulk;
 	mapAddr = 0;
 #endif
 	return 0;
@@ -273,13 +278,21 @@ static void *vm_acquire_internal(size_t size, int options)
 
 #if defined(HAVE_MACH_VM)
 	// vm_allocate() returns a zero-filled memory region
+#ifdef MEM_BULK
+	// In MEM_BULK mode, vm_init_reserved() carves out the reserved buffer
+	// from the bulk block later — don't add RESERVED_SIZE here.
+	kern_return_t ret_code = vm_allocate(mach_task_self(), (vm_address_t *)&addr, size, TRUE);
+#else
 	kern_return_t ret_code = vm_allocate(mach_task_self(), (vm_address_t *)&addr, reserved_buf ? size : size + RESERVED_SIZE, TRUE);
+#endif
 	if (ret_code != KERN_SUCCESS) {
 		errno = vm_error(ret_code);
 		return VM_MAP_FAILED;
 	}
+#ifndef MEM_BULK
 	if (!reserved_buf)
 		reserved_buf = (char *)addr + size;
+#endif
 #elif defined(HAVE_MMAP_VM)
 	int fd = zero_fd;
 	int the_map_flags = translate_map_flags(options) | map_flags;

--- a/SheepShaver/src/CrossPlatform/sigsegv.cpp
+++ b/SheepShaver/src/CrossPlatform/sigsegv.cpp
@@ -2663,7 +2663,10 @@ static void mach_set_thread_state(sigsegv_info_t *SIP)
 
 #if TARGET_OS_IPHONE
 
-#ifdef NATMEM_OFFSET
+#ifdef MEM_BULK
+// MEM_BULK: VMBaseDiff is set at runtime in vm_alloc.cpp
+extern unsigned long VMBaseDiff;
+#elif defined(NATMEM_OFFSET)
 const uint64_t VMBaseDiff = NATMEM_OFFSET;
 #else
 const uint64_t VMBaseDiff = 0;

--- a/SheepShaver/src/MacOSX/config/config-ios-aarch64.h
+++ b/SheepShaver/src/MacOSX/config/config-ios-aarch64.h
@@ -405,13 +405,10 @@
    ordering is the same as for multi-word integers. */
 /* #undef HOST_FLOAT_WORDS_BIG_ENDIAN */
 
-/* Define constant offset for Mac address translation: macosx-aarch64 is always 64bit */
-#if TARGET_OS_SIMULATOR
-#define NATMEM_OFFSET 0x400000000000
-#else
-// This works for arm devices
-#define NATMEM_OFFSET 0x000100000000
-#endif
+/* Use bulk memory allocation on iOS to avoid ASLR-related fixed-address
+   failures.  vm_init() reserves one contiguous region and sets VMBaseDiff
+   at runtime, so every Mac address maps reliably into host memory.  */
+#define MEM_BULK 1
 
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "Christian.Bauer@uni-mainz.de"

--- a/SheepShaver/src/MacOSX/config/config-ios-x86_64.h
+++ b/SheepShaver/src/MacOSX/config/config-ios-x86_64.h
@@ -405,8 +405,10 @@
    ordering is the same as for multi-word integers. */
 /* #undef HOST_FLOAT_WORDS_BIG_ENDIAN */
 
-/* Define constant offset for Mac address translation */
-#define NATMEM_OFFSET 0x400000000000
+/* Use bulk memory allocation on iOS to avoid ASLR-related fixed-address
+   failures.  vm_init() reserves one contiguous region and sets VMBaseDiff
+   at runtime, so every Mac address maps reliably into host memory.  */
+#define MEM_BULK 1
 
 /* Define to the address where bug reports for this package should be sent. */
 #define PACKAGE_BUGREPORT "Christian.Bauer@uni-mainz.de"

--- a/SheepShaver/src/Unix/main_unix.cpp
+++ b/SheepShaver/src/Unix/main_unix.cpp
@@ -1021,7 +1021,11 @@ int main(int argc, char *argv[])
 		goto quit;
 	
 	// Initialize VM system
-	vm_init();
+	if (vm_init() < 0) {
+		sprintf(str, "Could not initialize virtual memory system.\n");
+		ErrorAlert(str);
+		goto quit;
+	}
 	
 	// Get system info
 	get_system_info();
@@ -1145,6 +1149,7 @@ int main(int argc, char *argv[])
 			sprintf(str, GetString(STR_RAM_MMAP_ERR), strerror(errno));
 			ErrorAlert(str);
 			objc_displayRamAllocFailedAlert();
+			goto quit;
 		}
 		RAMBase = RAM_BASE;
 		RAMBaseHost = Mac2HostAddr(RAMBase);


### PR DESCRIPTION
## Problem

PocketShaver crashes on roughly half of iOS launches due to a memory allocation failure. The emulator maps RAM, ROM, and shared memory at fixed host addresses derived from a compile-time offset (NATMEM_OFFSET). iOS ASLR randomizes the process address space on every launch, so when system libraries or dyld happen to land at those addresses, the vm_allocate call fails. The current workaround shows a dialog asking the user to restart.

## Solution

Replace the compile-time fixed offset (NATMEM_OFFSET) with the existing MEM_BULK allocation strategy already used by the Windows port. On init, the VM system reserves one contiguous 1.5 GB region at whatever address the OS provides, then sets VMBaseDiff at runtime. All Mac-to-host address translations use this runtime offset, so allocations always succeed regardless of ASLR layout.

The guest OS retains full access to all configured RAM (32–512 MB) — only the host-side virtual address changes.

## Changes

- **config-ios-aarch64.h / config-ios-x86_64.h**: Replace `NATMEM_OFFSET` with `MEM_BULK 1`
- **vm_alloc.cpp**: Skip redundant 80 MB reserved-buffer padding in MEM_BULK mode (carved from the bulk block later by vm_init_reserved); add error check and diagnostic for bulk allocation failure
- **sigsegv.cpp**: Reference the runtime VMBaseDiff under MEM_BULK instead of a compile-time constant
- **main_unix.cpp**: Check vm_init() return value; add `goto quit` after RAM allocation failure instead of falling through with undefined state

## Verification

- Builds cleanly for iOS arm64 with Xcode 26 (zero new warnings)
- macOS SheepShaver configs are unaffected (no MEM_BULK defined)
- Tested on-device with iOS 26 on iPad and iPhone; further on-device testing needed to confirm launches are now 100% reliable across multiple OS versions and all RAM size settings (32–512 MB)

## Additional Significance

In addition to resolving an issue that could complicate App Store review and approval, **this pull request resolves the 100% failure rate of memory allocation when launching PocketShaver on macOS.** 