### PR TITLE
UX fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,6 @@ project.xcworkspace/
 *.xccheckout
 *.xcscmblueprint
 
-# Project resources
-resources/
-
 #
 # JetBrains IDE settings
 #

--- a/SheepShaver/src/MacOSX/PocketShaver.xcodeproj/project.pbxproj
+++ b/SheepShaver/src/MacOSX/PocketShaver.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		C7E2AFB92E16C55C00CF50D4 /* OverlayViewControllerObjC.mm in Sources */ = {isa = PBXBuildFile; fileRef = C7E2AFB82E16C55500CF50D4 /* OverlayViewControllerObjC.mm */; };
 		C7E2AFBC2E16CAAD00CF50D4 /* OverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E2AFBB2E16CAAA00CF50D4 /* OverlayViewController.swift */; };
 		C7E2AFC02E1962B000CF50D4 /* SDLKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E2AFBF2E19629A00CF50D4 /* SDLKey.swift */; };
+		C7E39D6C300CFC0000830438 /* ClipboardSharing.mm in Sources */ = {isa = PBXBuildFile; fileRef = C7E39D6B300CFBFA00830438 /* ClipboardSharing.mm */; };
 		C7E7B4A62EB7BFF6005844C2 /* PreferencesLicensesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E7B4A52EB7BFEA005844C2 /* PreferencesLicensesViewController.swift */; };
 		C7F42CCC2E5A0C8200FA7169 /* FatalErrorAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F42CCB2E5A0C6D00FA7169 /* FatalErrorAlertViewController.swift */; };
 		C7F42CCE2E5A0F6F00FA7169 /* FatalErrorAlertViewControllerObjC.mm in Sources */ = {isa = PBXBuildFile; fileRef = C7F42CCD2E5A0F6B00FA7169 /* FatalErrorAlertViewControllerObjC.mm */; };
@@ -857,6 +858,8 @@
 		C7E2AFBA2E16C57900CF50D4 /* OverlayViewControllerObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OverlayViewControllerObjC.h; sourceTree = "<group>"; };
 		C7E2AFBB2E16CAAA00CF50D4 /* OverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayViewController.swift; sourceTree = "<group>"; };
 		C7E2AFBF2E19629A00CF50D4 /* SDLKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDLKey.swift; sourceTree = "<group>"; };
+		C7E39D6B300CFBFA00830438 /* ClipboardSharing.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ClipboardSharing.mm; sourceTree = "<group>"; };
+		C7E39D6D300CFC6200830438 /* ClipboardSharing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ClipboardSharing.h; sourceTree = "<group>"; };
 		C7E7B4A52EB7BFEA005844C2 /* PreferencesLicensesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesLicensesViewController.swift; sourceTree = "<group>"; };
 		C7F42CCB2E5A0C6D00FA7169 /* FatalErrorAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FatalErrorAlertViewController.swift; sourceTree = "<group>"; };
 		C7F42CCD2E5A0F6B00FA7169 /* FatalErrorAlertViewControllerObjC.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FatalErrorAlertViewControllerObjC.mm; sourceTree = "<group>"; };
@@ -1838,6 +1841,7 @@
 				C77F12212F39D4FD0033BE25 /* Gamepad */,
 				C77F12242F39D5750033BE25 /* Bonjour */,
 				C74035A92EDAEC1C0045B9C6 /* Performance counter */,
+				C7E39D6A300CFBCD00830438 /* Clipboard Sharing */,
 				GFXA10A1B2C3D4E5F60010 /* GfxAccel */,
 			);
 			path = Services;
@@ -2112,6 +2116,16 @@
 			path = Swift;
 			sourceTree = "<group>";
 		};
+		C7E39D6A300CFBCD00830438 /* Clipboard Sharing */ = {
+			isa = PBXGroup;
+			children = (
+				E204B9E728BC7CE80081FDCA /* clip_ios.mm */,
+				C7E39D6B300CFBFA00830438 /* ClipboardSharing.mm */,
+				C7E39D6D300CFC6200830438 /* ClipboardSharing.h */,
+			);
+			path = "Clipboard Sharing";
+			sourceTree = "<group>";
+		};
 		C7E7B4A42EB7BFCF005844C2 /* Licenses */ = {
 			isa = PBXGroup;
 			children = (
@@ -2217,7 +2231,6 @@
 			isa = PBXGroup;
 			children = (
 				C7E2AFBE2E19629100CF50D4 /* Swift */,
-				E204B9E728BC7CE80081FDCA /* clip_ios.mm */,
 				C74B222D2ED78079003D0F71 /* sheepicon.png */,
 				E204B9C128BC7BF10081FDCA /* Info.plist */,
 				E204B99E28BC7BF00081FDCA /* iOS Launch Screen.storyboard */,
@@ -2729,6 +2742,7 @@
 				NQD10A1B2C3D4E5F60201 /* nqd_metal_renderer.mm in Sources */,
 				NQD10A1B2C3D4E5F60202 /* nqd_shaders.metal in Sources */,
 				MTLD00000000000000000002 /* metal_device_shared.mm in Sources */,
+				C7E39D6C300CFC0000830438 /* ClipboardSharing.mm in Sources */,
 				COMP10A1B2C3D4E5F60201 /* metal_compositor.mm in Sources */,
 				COMP10A1B2C3D4E5F60202 /* compositor_shaders.metal in Sources */,
 				COMP10A1B2C3D4E5F60402 /* metal_compositor_submitframe.mm in Sources */,

--- a/SheepShaver/src/MacOSX/PocketShaver.xcodeproj/project.pbxproj
+++ b/SheepShaver/src/MacOSX/PocketShaver.xcodeproj/project.pbxproj
@@ -3280,7 +3280,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = 2LK9LNU9V8;
+				DEVELOPMENT_TEAM = 7K4RY698N6;
 				ENABLE_TESTABILITY = YES;
 				EXCLUDED_RECURSIVE_SEARCH_PATH_SUBDIRECTORIES = "*.nib *.lproj *.gch *.xcode* *.xcassets (*) .DS_Store CVS .svn .git .hg *.pbproj *.pbxproj *.framework";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3403,7 +3403,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = 2LK9LNU9V8;
+				DEVELOPMENT_TEAM = 7K4RY698N6;
 				ENABLE_TESTABILITY = NO;
 				EXCLUDED_RECURSIVE_SEARCH_PATH_SUBDIRECTORIES = "*.nib *.lproj *.gch *.xcode* *.xcassets (*) .DS_Store CVS .svn .git .hg *.pbproj *.pbxproj *.framework";
 				FRAMEWORK_SEARCH_PATHS = (

--- a/SheepShaver/src/MacOSX/PocketShaver.xcodeproj/xcshareddata/xcschemes/PocketShaver.xcscheme
+++ b/SheepShaver/src/MacOSX/PocketShaver.xcodeproj/xcshareddata/xcschemes/PocketShaver.xcscheme
@@ -1,35 +1,95 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<Scheme LastUpgradeVersion="1600" version="1.3">
-   <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
-            <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="E204B92728BC3EBE0081FDCA" BuildableName="PocketShaver.app" BlueprintName="PocketShaver" ReferencedContainer="container:PocketShaver.xcodeproj">
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E204B92728BC3EBE0081FDCA"
+               BuildableName = "PocketShaver.app"
+               BlueprintName = "PocketShaver"
+               ReferencedContainer = "container:PocketShaver.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
-   <TestAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES">
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
    </TestAction>
-   <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="NO" debugDocumentVersioning="YES" debugServiceExtension="internal" allowLocationSimulation="YES">
-      <BuildableProductRunnable runnableDebuggingMode="0">
-         <BuildableReference BuildableIdentifier="primary" BlueprintIdentifier="E204B92728BC3EBE0081FDCA" BuildableName="PocketShaver.app" BlueprintName="PocketShaver" ReferencedContainer="container:PocketShaver.xcodeproj">
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E204B92728BC3EBE0081FDCA"
+            BuildableName = "PocketShaver.app"
+            BlueprintName = "PocketShaver"
+            ReferencedContainer = "container:PocketShaver.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <EnvironmentVariables>
-         <EnvironmentVariable key="MTL_DEBUG_LAYER" value="1" isEnabled="YES">
+         <EnvironmentVariable
+            key = "MTL_DEBUG_LAYER"
+            value = "1"
+            isEnabled = "YES">
          </EnvironmentVariable>
-         <EnvironmentVariable key="MTL_SHADER_VALIDATION" value="1" isEnabled="YES">
+         <EnvironmentVariable
+            key = "MTL_SHADER_VALIDATION"
+            value = "1"
+            isEnabled = "YES">
          </EnvironmentVariable>
-         <EnvironmentVariable key="MTL_DEBUG_LAYER_ERROR_MODE" value="assert" isEnabled="YES">
+         <EnvironmentVariable
+            key = "MTL_DEBUG_LAYER_ERROR_MODE"
+            value = "assert"
+            isEnabled = "YES">
          </EnvironmentVariable>
-      <EnvironmentVariable key="GFXACCEL_LOG" value="all" isEnabled="YES" /><EnvironmentVariable key="GFXACCEL_LOG_VERBOSE" value="1" isEnabled="YES" /></EnvironmentVariables>
+         <EnvironmentVariable
+            key = "GFXACCEL_LOG"
+            value = "all"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "GFXACCEL_LOG_VERBOSE"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
-   <ProfileAction buildConfiguration="Release" shouldUseLaunchSchemeArgsEnv="YES" savedToolIdentifier="" useCustomWorkingDirectory="NO" debugDocumentVersioning="YES">
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
    </ProfileAction>
-   <AnalyzeAction buildConfiguration="Debug">
+   <AnalyzeAction
+      buildConfiguration = "Debug">
    </AnalyzeAction>
-   <ArchiveAction buildConfiguration="Release" revealArchiveInOrganizer="YES">
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Gamepad/Gamepad.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Gamepad/Gamepad.swift
@@ -118,7 +118,8 @@ extension GamepadConfig {
 				.init(position: .init(side: .left, row: 3, index: 0), assignment: .key(.escape)),
 				.init(position: .init(side: .right, row: 1, index: 1), assignment: .joystick(.mouse)),
 				.init(position: .init(side: .right, row: 2, index: 0), assignment: .key(.space)),
-				.init(position: .init(side: .right, row: 3, index: 0), assignment: .key(.enter))
+				.init(position: .init(side: .right, row: 3, index: 0), assignment: .key(.enter)),
+				.init(position: .init(side: .left, row: 0, index: 3), assignment: .specialButton(.relativeMouseModeEnabled))
 			],
 			visibilitySetting: .both
 		)

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Gamepad/SpecialButton.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Gamepad/SpecialButton.swift
@@ -17,18 +17,22 @@ enum SpecialButton: String, Codable, CaseIterable {
 	case hoverFarAboveToggle
 	case audioEnabled
 	case relativeMouseModeEnabled
+	case copyClipboardHostToGuest
+	case copyClipboardGuestToHost
 
 	var label: String {
 		switch self {
-		case .hoverJustAboveToggle: return "Hover just above (toggle)"
-		case .hoverFarAboveToggle: return "Hover far above (toggle)"
-		case .hoverSidewaysToggle: return "Hover sideways (toggle)"
-		case .hoverDiagonallyToggle: return "Hover diagonally (toggle)"
-		case .mouseClick: return "Mouse click"
-		case .cmdW: return "Cmd-W"
-		case .rightClick: return "Right click"
-		case .audioEnabled: return "Audio enabled"
-		case .relativeMouseModeEnabled: return "Relative mouse mode enabled (toggle)"
+		case .hoverJustAboveToggle: "Hover just above (toggle)"
+		case .hoverFarAboveToggle: "Hover far above (toggle)"
+		case .hoverSidewaysToggle: "Hover sideways (toggle)"
+		case .hoverDiagonallyToggle: "Hover diagonally (toggle)"
+		case .mouseClick: "Mouse click"
+		case .cmdW: "Cmd-W"
+		case .rightClick: "Right click"
+		case .audioEnabled: "Audio enabled"
+		case .relativeMouseModeEnabled: "Relative mouse mode enabled (toggle)"
+		case .copyClipboardHostToGuest: "Copy iOS clipboard to Classic Mac OS"
+		case .copyClipboardGuestToHost: "Copy Classic Mac OS clipboard to iOS"
 		}
 	}
 }

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Miscellaneous/MiscellaneousSettings.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Miscellaneous/MiscellaneousSettings.swift
@@ -165,11 +165,6 @@ class MiscellaneousSettings: Codable {
 		rightClickSetting = .control
 		keyboardAutoOffsetSetting = .middle
 		hoverJustAboveOffsetModifier = 1
-		// Default to the raw guest gamma. The `.osDefined` correction lifts
-		// midtones (classic-Mac 1.8 -> sRGB 2.2) and reads as too bright /
-		// washed-out at launch on modern displays; users can still opt into it
-		// in Preferences. Existing installs are moved by
-		// migrateGammaRampDefaultIfNeeded().
 		gammaRampSetting = .linear
 		bootInRelativeMouseMode = false
 		ignoreIllegalInstructions = false
@@ -210,6 +205,8 @@ class MiscellaneousSettings: Codable {
 		return settings
 	}()
 
+	/// The `.osDefined` correction lifts midtones (classic-Mac 1.8 -> sRGB 2.2)
+	/// and reads as too bright / washed-out at launch on modern displays
 	/// One-time migration for the gamma-ramp default change (`.osDefined` ->
 	/// `.linear`). Installs that pre-date the change still hold the old default
 	/// in their persisted settings, so flipping `init()` alone would not reach
@@ -223,7 +220,7 @@ class MiscellaneousSettings: Codable {
 		defaults.set(true, forKey: marker)
 
 		if gammaRampSetting == .osDefined {
-			set(gammaRampSetting: .linear) // persists via saveAsCurrent()
+			set(gammaRampSetting: .linear)
 		}
 	}
 

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Miscellaneous/MiscellaneousSettings.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Miscellaneous/MiscellaneousSettings.swift
@@ -57,6 +57,11 @@ enum GammaRampSetting: String, Codable, CaseIterable {
 	case osDefined
 }
 
+enum ClipboardSharingSetting: String, Codable, CaseIterable {
+	case manual
+	case automatic
+}
+
 class MiscellaneousSettings: Codable {
 	private(set) var showHints: Bool
 	private(set) var iPadMousePassthrough: Bool
@@ -91,15 +96,13 @@ class MiscellaneousSettings: Codable {
 	private(set) var ignoreIllegalInstructions: Bool
 	private(set) var altivecEnabled: Bool
 	private(set) var ramInMb: Int
-	// Optional so persisted settings that pre-date the key still decode: the
-	// synthesized decoder uses decodeIfPresent for optionals, while a missing
-	// required key would throw and silently reset every saved setting
-	private(set) var jitEnabled: Bool?
-
-	var jitCompilerEnabled: Bool {
-		jitEnabled ?? false
+	private(set) var jitCompilerEnabled: Bool
+	private(set) var clipboardSharing: ClipboardSharingSetting {
+		didSet {
+			LocalNotification.send(.clipboardSharingSettingChanged)
+		}
 	}
-
+	private(set) var reportClipboardSharingActivity: Bool
 
 	var secondFingerClick: Bool {
 		twoFingerSteeringSetting != .off
@@ -154,7 +157,7 @@ class MiscellaneousSettings: Codable {
 		audioEnabled = true
 		fpsReporting = false
 		networkTransferRateReportingEnabled = false
-		frameRateSetting = .f60hz
+		frameRateSetting = .f120hz
 		alwaysLandscapeMode = Self.shouldDisplayAlwaysLandscapeModeOption
 		twoFingerSteeringSetting = .off
 		relativeMouseModeSetting = .manual
@@ -173,9 +176,13 @@ class MiscellaneousSettings: Codable {
 		altivecEnabled = true
 		ramInMb = 512
 		#if targetEnvironment(macCatalyst)
-		jitEnabled = true // JIT ships on by default on Mac Catalyst
+		jitCompilerEnabled = true
+		clipboardSharing = .automatic
+		reportClipboardSharingActivity = false
 		#else
-		jitEnabled = false
+		jitCompilerEnabled = false
+		clipboardSharing = .manual
+		reportClipboardSharingActivity = true
 		#endif
 	}
 
@@ -390,7 +397,7 @@ class MiscellaneousSettings: Codable {
 
 	@MainActor
 	func set(jitCompilerEnabled: Bool) {
-		self.jitEnabled = jitCompilerEnabled
+		self.jitCompilerEnabled = jitCompilerEnabled
 
 		saveAsCurrent()
 	}
@@ -398,6 +405,20 @@ class MiscellaneousSettings: Codable {
 	@MainActor
 	func set(ramInMb: Int) {
 		self.ramInMb = ramInMb
+
+		saveAsCurrent()
+	}
+
+	@MainActor
+	func set(clipboardSharing: ClipboardSharingSetting) {
+		self.clipboardSharing = clipboardSharing
+
+		saveAsCurrent()
+	}
+
+	@MainActor
+	func set(reportClipboardSharingActivity: Bool) {
+		self.reportClipboardSharingActivity = reportClipboardSharingActivity
 
 		saveAsCurrent()
 	}
@@ -468,5 +489,10 @@ public class MiscellaneousSettingsObjC: NSObject {
 	@MainActor
 	static func getRamInMb() -> Int {
 		MiscellaneousSettings.current.ramInMb
+	}
+
+	@MainActor
+	static func isClipboardSharingAutomatic() -> Bool {
+		MiscellaneousSettings.current.clipboardSharing == .automatic
 	}
 }

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Miscellaneous/MiscellaneousSettingsObjC.mm
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Miscellaneous/MiscellaneousSettingsObjC.mm
@@ -86,3 +86,7 @@ bool objc_getAltivec(void) {
 int objc_getRamInMb(void) {
 	return (int)MiscellaneousSettingsObjC.getRamInMb;
 }
+
+bool objc_getIsClipboardSharingAutomatic(void) {
+	return MiscellaneousSettingsObjC.isClipboardSharingAutomatic;
+}

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Miscellaneous/MiscellaneousSettingsObjCCppHeader.h
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Models and Persistence/Miscellaneous/MiscellaneousSettingsObjCCppHeader.h
@@ -18,3 +18,4 @@ bool objc_getShouldBootInRelativeMouseMode(void);
 bool objc_getIgnoreIllegalInstructions(void);
 bool objc_getAltivec(void);
 int objc_getRamInMb(void);
+bool objc_getIsClipboardSharingAutomatic(void);

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/Gamepad Layer/Assign Button/GamepadAssignButtonModel.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/Gamepad Layer/Assign Button/GamepadAssignButtonModel.swift
@@ -117,7 +117,7 @@ extension GamepadButtonAssignment {
 		case .key:
 			return "The key \(identifier)."
 		case .specialButton(let specialButton):
-			switch specialButton{
+			switch specialButton {
 			case .hoverJustAboveToggle:
 				return "Touch input hovers mouse cursor without clicking, offset slightly above the of the touch point. This makes content easier to interact with, while avoiding to obscure the content itelf with your finger. Recommended to use in combination with Second finger click functionality or a Mouse click gamepad button."
 			case .hoverSidewaysToggle:
@@ -136,6 +136,10 @@ extension GamepadButtonAssignment {
 				return "Toggle audio enabled. Sound from other apps is lowered if audio is enabled."
 			case .relativeMouseModeEnabled:
 				return "Toggle relative mouse mode (more info on this mode in Preferences under Advanced tab)."
+			case .copyClipboardHostToGuest:
+				return "Copies iOS clipboard to Classic Mac OS clipboard, if content is text or image."
+			case .copyClipboardGuestToHost:
+				return "Copy Classic Mac OS clipboard to iOS clipboard, if content is text or image."
 			}
 		case .joystick(let joystickType):
 			switch joystickType {

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/Gamepad Layer/GamepadButton.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/Gamepad Layer/GamepadButton.swift
@@ -270,15 +270,17 @@ extension SpecialButton {
 extension SpecialButton {
 	var gamepadLabel: GamepadButton.Label {
 		switch self {
-		case .mouseClick: return .icon(.leftclick)
-		case .hoverJustAboveToggle: return .twoIcons(.handRaised, .chevronCompactUp)
-		case .hoverFarAboveToggle: return .twoIcons(.handRaised, .arrowUp)
-		case .hoverSidewaysToggle: return .twoIcons(.handRaised, .arrowLeftArrowRight)
-		case .hoverDiagonallyToggle: return .twoIcons(.handRaised, .crossArrow)
-		case .cmdW: return .text("⌘-W")
-		case .rightClick: return .icon(.rightclick)
-		case .audioEnabled: return .icon(.speakerSlash) // placeholder
-		case .relativeMouseModeEnabled: return .thinIcon(.arrowUpAndDownAndArrowLeftAndRight)
+		case .mouseClick: .icon(.leftclick)
+		case .hoverJustAboveToggle: .twoIcons(.handRaised, .chevronCompactUp)
+		case .hoverFarAboveToggle: .twoIcons(.handRaised, .arrowUp)
+		case .hoverSidewaysToggle: .twoIcons(.handRaised, .arrowLeftArrowRight)
+		case .hoverDiagonallyToggle: .twoIcons(.handRaised, .crossArrow)
+		case .cmdW: .text("⌘-W")
+		case .rightClick: .icon(.rightclick)
+		case .audioEnabled: .icon(.speakerSlash) // placeholder
+		case .relativeMouseModeEnabled: .thinIcon(.arrowUpAndDownAndArrowLeftAndRight)
+		case .copyClipboardHostToGuest: .icon(.arrowRightPageOnClipboard)
+		case .copyClipboardGuestToHost: .icon(.arrowLeftPageOnClipboard)
 		}
 	}
 }

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/Hidden input field/HiddenInputField.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/Hidden input field/HiddenInputField.swift
@@ -10,6 +10,8 @@ import UIKit
 class HiddenInputField: UITextField {
 	init(
 		inputInteractionModel: InputInteractionModel,
+		didTapClipboardHostToGuestButton: @escaping (() -> Void),
+		didTapClipboardGuestToHostButton: @escaping (() -> Void),
 		didTapPreferencesButton: @escaping (() -> Void),
 		didTapDismissKeyboardButton: @escaping (() -> Void),
 		hiddenInputFieldDelegate: HiddenInputFieldDelegate
@@ -25,6 +27,8 @@ class HiddenInputField: UITextField {
 		delegate = hiddenInputFieldDelegate
 		let accessoryView = HiddenInputFieldKeyboardAccessoryView(
 			inputInteractionModel: inputInteractionModel,
+			didTapClipboardHostToGuestButton: didTapClipboardHostToGuestButton,
+			didTapClipboardGuestToHostButton: didTapClipboardGuestToHostButton,
 			didTapPreferencesButton: didTapPreferencesButton,
 			didTapDismissKeyboardButton: didTapDismissKeyboardButton
 		)

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/Hidden input field/HiddenInputFieldKeyboardAccessoryView.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/Hidden input field/HiddenInputFieldKeyboardAccessoryView.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Combine
 
 class HiddenInputFieldKeyboardAccessoryView: UIView {
 	private lazy var leftStackView: UIStackView = {
@@ -32,14 +31,25 @@ class HiddenInputFieldKeyboardAccessoryView: UIView {
 		createButton(title: "⇧")
 	}()
 
-	private lazy var relativeMouseModeButton: UIButton = {
+	private lazy var copyClipboardHostToGuestButton: UIButton = {
 		let button = UIButton.withoutConstraints()
-		button.setImage(ImageResource.arrowUpAndDownAndArrowLeftAndRight.asSymbolImage(),
+		button.setImage(Assets.arrowRightPageOnClipboard.asSymbolImage(),
 			for: .normal
 		)
 		button.configuration = buttonConfig()
 		button.layer.cornerRadius = 8
-		button.addTarget(self, action: #selector(relativeMouseModeButtonPushed), for: .touchUpInside)
+		button.addTarget(self, action: #selector(copyClipboardHostToGuestButtonPushed), for: .touchUpInside)
+		return button
+	}()
+
+	private lazy var copyClipboardGuestToHostButton: UIButton = {
+		let button = UIButton.withoutConstraints()
+		button.setImage(Assets.arrowLeftPageOnClipboard.asSymbolImage(),
+			for: .normal
+		)
+		button.configuration = buttonConfig()
+		button.layer.cornerRadius = 8
+		button.addTarget(self, action: #selector(copyClipboardGuestToHostButtonPushed), for: .touchUpInside)
 		return button
 	}()
 
@@ -77,6 +87,8 @@ class HiddenInputFieldKeyboardAccessoryView: UIView {
 
 
 	private let inputInteractionModel: InputInteractionModel
+	private let didTapClipboardHostToGuestButton: (() -> Void)
+	private let didTapClipboardGuestToHostButton: (() -> Void)
 	private let didTapPreferencesButton: (() -> Void)
 	private let didTapDismissKeyboardButton: (() -> Void)
 
@@ -85,14 +97,16 @@ class HiddenInputFieldKeyboardAccessoryView: UIView {
 
 	private let deviceScreenSize = UIScreen.deviceScreenSize
 
-	private var anyCancellables = Set<AnyCancellable>()
-
 	init(
 		inputInteractionModel: InputInteractionModel,
+		didTapClipboardHostToGuestButton: @escaping (() -> Void),
+		didTapClipboardGuestToHostButton: @escaping (() -> Void),
 		didTapPreferencesButton: @escaping (() -> Void),
 		didTapDismissKeyboardButton: @escaping (() -> Void)
 	) {
 		self.inputInteractionModel = inputInteractionModel
+		self.didTapClipboardHostToGuestButton = didTapClipboardHostToGuestButton
+		self.didTapClipboardGuestToHostButton = didTapClipboardGuestToHostButton
 		self.didTapPreferencesButton = didTapPreferencesButton
 		self.didTapDismissKeyboardButton = didTapDismissKeyboardButton
 
@@ -113,20 +127,23 @@ class HiddenInputFieldKeyboardAccessoryView: UIView {
 
 		let spacing: CGFloat
 		let sideMargin: CGFloat
-		switch deviceScreenSize {
-		case .normal:
+		switch (deviceScreenSize, UIScreen.isPortraitMode) {
+		case (.normal, _):
 			spacing = 8
 			sideMargin = 16
-		case .small:
+		case (.small, false):
 			spacing = 4
 			sideMargin = 8
-			relativeMouseModeButton.setTargetWidth(44)
+			copyClipboardHostToGuestButton.setTargetWidth(44)
+			copyClipboardGuestToHostButton.setTargetWidth(44)
 			preferencesButton.setTargetWidth(44)
 			dismissKeyboardButton.setTargetWidth(44)
-		case .tiny:
+		case (.small, true),
+			(.tiny, _):
 			spacing = 3
 			sideMargin = 4
-			relativeMouseModeButton.setTargetWidth(38)
+			copyClipboardHostToGuestButton.setTargetWidth(38)
+			copyClipboardGuestToHostButton.setTargetWidth(38)
 			preferencesButton.setTargetWidth(38)
 			dismissKeyboardButton.setTargetWidth(38)
 		}
@@ -139,7 +156,8 @@ class HiddenInputFieldKeyboardAccessoryView: UIView {
 		leftStackView.addArrangedSubview(ctrlButton)
 		leftStackView.addArrangedSubview(shiftButton)
 
-		rightStackView.addArrangedSubview(relativeMouseModeButton)
+		rightStackView.addArrangedSubview(copyClipboardHostToGuestButton)
+		rightStackView.addArrangedSubview(copyClipboardGuestToHostButton)
 		rightStackView.addArrangedSubview(preferencesButton)
 		if !UIScreen.isPortraitMode || UIDevice.isIPadIdiom {
 			rightStackView.addArrangedSubview(rightCmdButton)
@@ -147,7 +165,6 @@ class HiddenInputFieldKeyboardAccessoryView: UIView {
 		if !UIDevice.isIPadIdiom {
 			rightStackView.addArrangedSubview(dismissKeyboardButton)
 		}
-
 
 		NSLayoutConstraint.activate([
 			leftStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: sideMargin),
@@ -193,33 +210,13 @@ class HiddenInputFieldKeyboardAccessoryView: UIView {
 			)
 		}
 
-		configure(canToggleRelativeMouseMode: inputInteractionModel.canToggleRelativeMouseMode)
-		configure(isRelativeMouseModeEnabled: inputInteractionModel.isRelativeMouseModeEnabled)
-
 		listenToChanges()
 	}
 	
 	required init?(coder: NSCoder) { fatalError() }
 
 	private func listenToChanges() {
-		inputInteractionModel.changeSubject.sink{ [weak self] change in
-			guard let self else { return }
-			switch change {
-			case .relativeMouseModeChanged(let isEnabled):
-				configure(isRelativeMouseModeEnabled: isEnabled)
-			case .canToggleRelativeMouseModeChanged(let isEnabled):
-				configure(canToggleRelativeMouseMode: isEnabled)
-			default: break
-			}
-		}.store(in: &anyCancellables)
-	}
-
-	private func configure(canToggleRelativeMouseMode: Bool) {
-		relativeMouseModeButton.isHidden = !canToggleRelativeMouseMode
-	}
-
-	private func configure(isRelativeMouseModeEnabled: Bool) {
-		relativeMouseModeButton.configuration!.baseBackgroundColor = isRelativeMouseModeEnabled ? .gray : .lightGray
+		LocalNotification.observe(.clipboardSharingSettingChanged, self, #selector(updateClipboardSharingButtonVisiblity))
 	}
 
 	@objc private func cmdPushed() {
@@ -254,8 +251,12 @@ class HiddenInputFieldKeyboardAccessoryView: UIView {
 		releaseKey?(SDLKey.shift)
 	}
 
-	@objc private func relativeMouseModeButtonPushed() {
-		inputInteractionModel.toggleRelativeMouseMode()
+	@objc private func copyClipboardGuestToHostButtonPushed() {
+		didTapClipboardGuestToHostButton();
+	}
+
+	@objc private func copyClipboardHostToGuestButtonPushed() {
+		didTapClipboardHostToGuestButton();
 	}
 
 	@objc private func preferencesButtonPushed() {
@@ -273,6 +274,12 @@ class HiddenInputFieldKeyboardAccessoryView: UIView {
 		button.backgroundColor = .gray
 		button.layer.cornerRadius = 8
 		return button
+	}
+
+	@objc private func updateClipboardSharingButtonVisiblity() {
+		let isHidden = MiscellaneousSettings.current.clipboardSharing == .automatic
+		copyClipboardGuestToHostButton.isHidden = isHidden
+		copyClipboardHostToGuestButton.isHidden = isHidden
 	}
 }
 

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/Model/InputInteractionModel.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/Model/InputInteractionModel.swift
@@ -198,6 +198,14 @@ class InputInteractionModel {
 			if !isDown {
 				toggleRelativeMouseMode()
 			}
+		case .copyClipboardHostToGuest:
+			if !isDown {
+				objc_copyHostClipboardToGuestScrap()
+			}
+		case .copyClipboardGuestToHost:
+			if !isDown {
+				objc_copyGuestScrapToHostClipboard()
+			}
 		}
 	}
 

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/OverlayViewController.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Overlay/OverlayViewController.swift
@@ -92,6 +92,12 @@ public class OverlayViewController: UIViewController {
 		guard let self else { fatalError() }
 		return HiddenInputField(
 			inputInteractionModel: inputInteractionModel,
+			didTapClipboardHostToGuestButton: {
+				objc_copyHostClipboardToGuestScrap();
+			},
+			didTapClipboardGuestToHostButton: {
+				objc_copyGuestScrapToHostClipboard();
+			},
 			didTapPreferencesButton: { [weak self] in
 				self?.presentPreferences()
 			},
@@ -274,7 +280,6 @@ public class OverlayViewController: UIViewController {
 			guard let self else { return }
 			switch change {
 			case .relativeMouseModeChanged(let isEnabled):
-
 				var hint: String
 				if isEnabled {
 					hint = "Relative mouse mode on"
@@ -300,6 +305,8 @@ public class OverlayViewController: UIViewController {
 		LocalNotification.observe(.gotIpAddress, self, #selector(displayGotIpAddress))
 		LocalNotification.observe(.displayPreferencesRequested, self, #selector(presentPreferences))
 		LocalNotification.observe(.enteredKeyboardModeWhileUsingHardwareKeyboard, self, #selector(handleEnteredKeyboardModeWhileUsingHardwareKeyboard))
+		LocalNotification.observe(.clipboardSharingGuestToHost, self, #selector(displayClipboardSharingGuestToHostPerformed))
+		LocalNotification.observe(.clipboardSharingHostToGuest, self, #selector(displayClipboardSharingHostToGuestPerformed))
 		NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillChangePosition), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
 		NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidChangePosition), name: UIResponder.keyboardDidChangeFrameNotification, object: nil)
 	}
@@ -487,6 +494,8 @@ public class OverlayViewController: UIViewController {
 		sdlView.transform = transform
 		view.transform = transform.inverted()
 	}
+
+	
 
 	@objc
 	private func presentPreferences() {
@@ -705,6 +714,62 @@ public class OverlayViewController: UIViewController {
 		informationView.show(
 			hint: "Keyboard mode not available while using hardware keyboard",
 			atBottom: true
+		)
+	}
+
+	@objc
+	private func displayClipboardSharingGuestToHostPerformed(notification: Notification) {
+		guard MiscellaneousSettings.current.reportClipboardSharingActivity,
+			let content = notification.object as? ClipboardSharingContent else {
+			return
+		}
+
+		let osLabel = UIDevice.deviceType.osLabel
+		let hint: String
+		switch content {
+		case .text:
+			hint = "Copied text to \(osLabel) clipboard"
+		case .image:
+			hint = "Copied image to \(osLabel) clipboard"
+		case .alreadyCopied:
+			// Will in practive never be executed, since we don't want to ask for host
+			// clipboard read permission just to check if contents were the same
+			hint = "Clipboard contents were already identical"
+		case .empty:
+			hint = "Classic Mac OS clipboard was empty or identical"
+		}
+
+		informationView.show(
+			hintIcon: .arrowLeftPageOnClipboard,
+			hint: hint,
+			atBottom: state != .showingKeyboard
+		)
+	}
+
+	@objc
+	private func displayClipboardSharingHostToGuestPerformed(notification: Notification) {
+		guard MiscellaneousSettings.current.reportClipboardSharingActivity,
+			let content = notification.object as? ClipboardSharingContent else {
+			return
+		}
+
+		let osLabel = UIDevice.deviceType.osLabel
+		let hint: String
+		switch content {
+		case .text:
+			hint = "Copied text to Classic Mac OS clipboard"
+		case .image:
+			hint = "Copied image to Classic Mac OS clipboard"
+		case .alreadyCopied:
+			hint = "Clipboard contents were already identical"
+		case .empty:
+			hint = "\(osLabel) clipboard was empty"
+		}
+
+		informationView.show(
+			hintIcon: .arrowRightPageOnClipboard,
+			hint: hint,
+			atBottom: state != .showingKeyboard
 		)
 	}
 

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Advanced/PreferencesAdvancedCells.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Advanced/PreferencesAdvancedCells.swift
@@ -14,25 +14,6 @@ class PreferencesAdvancedRamStepperCell: UITableViewCell {
 
 	private let didChangeStepperValue: ((PreferencesGeneralRamSetting) -> Void)
 
-#if targetEnvironment(macCatalyst)
-	// UIStepper throws when it enters the Mac Catalyst window hierarchy (the Mac
-	// idiom has no discrete stepper and no preferredBehavioralStyle escape hatch),
-	// so Catalyst gets a −/+ button pair with the same UX. iOS/iPadOS keep the
-	// native UIStepper (in the #else below) for its standard appearance.
-	private let maxValue = PreferencesGeneralRamSetting.allCases.count - 1
-	private var currentValue: Int
-
-	private lazy var decrementButton = Self.makeStepButton(title: "\u{2212}") // MINUS SIGN
-	private lazy var incrementButton = Self.makeStepButton(title: "+")
-
-	private lazy var stepperControl: UIStackView = {
-		let stack = UIStackView(arrangedSubviews: [decrementButton, incrementButton])
-		stack.translatesAutoresizingMaskIntoConstraints = false
-		stack.axis = .horizontal
-		stack.spacing = 8
-		return stack
-	}()
-#else
 	private lazy var stepperControl: UIStepper = {
 		let stepper = UIStepper.withoutConstraints()
 		stepper.isContinuous = false
@@ -41,16 +22,12 @@ class PreferencesAdvancedRamStepperCell: UITableViewCell {
 		stepper.addTarget(self, action: #selector(stepperValueChanged), for: .valueChanged)
 		return stepper
 	}()
-#endif
 
 	init(
 		initialRamSettting: PreferencesGeneralRamSetting,
 		didChangeStepperValue: @escaping ((PreferencesGeneralRamSetting) -> Void)
 	) {
 		self.didChangeStepperValue = didChangeStepperValue
-#if targetEnvironment(macCatalyst)
-		self.currentValue = initialRamSettting.rawValue
-#endif
 
 		super.init(style: .default, reuseIdentifier: nil)
 
@@ -58,12 +35,7 @@ class PreferencesAdvancedRamStepperCell: UITableViewCell {
 
 		hideSeparator()
 
-#if targetEnvironment(macCatalyst)
-		decrementButton.addTarget(self, action: #selector(decrementValue), for: .touchUpInside)
-		incrementButton.addTarget(self, action: #selector(incrementValue), for: .touchUpInside)
-#else
 		stepperControl.value = Double(initialRamSettting.rawValue)
-#endif
 
 		contentView.addSubview(stepperControl)
 		contentView.addSubview(stepperLabel)
@@ -82,7 +54,68 @@ class PreferencesAdvancedRamStepperCell: UITableViewCell {
 
 	required init?(coder: NSCoder) { fatalError() }
 
-#if targetEnvironment(macCatalyst)
+	@objc private func stepperValueChanged() {
+		let stepperValue = Int(stepperControl.value)
+		let ramSetting = PreferencesGeneralRamSetting(rawValue: stepperValue) ?? .n256
+		stepperLabel.text = ramSetting.label
+		didChangeStepperValue(ramSetting)
+	}
+}
+
+class PreferencesAdvancedMacRamStepperCell: UITableViewCell {
+	private lazy var stepperLabel: UILabel = {
+		UILabel.withoutConstraints()
+	}()
+
+	private let didChangeStepperValue: ((PreferencesGeneralRamSetting) -> Void)
+
+	private let maxValue = PreferencesGeneralRamSetting.allCases.count - 1
+	private var currentValue: Int
+
+	private lazy var decrementButton = Self.makeStepButton(title: "\u{2212}") // Minus sign
+	private lazy var incrementButton = Self.makeStepButton(title: "+")
+
+	private lazy var stepperControl: UIStackView = {
+		let stack = UIStackView(arrangedSubviews: [decrementButton, incrementButton])
+		stack.translatesAutoresizingMaskIntoConstraints = false
+		stack.axis = .horizontal
+		stack.spacing = 8
+		return stack
+	}()
+
+	init(
+		initialRamSettting: PreferencesGeneralRamSetting,
+		didChangeStepperValue: @escaping ((PreferencesGeneralRamSetting) -> Void)
+	) {
+		self.didChangeStepperValue = didChangeStepperValue
+		self.currentValue = initialRamSettting.rawValue
+
+		super.init(style: .default, reuseIdentifier: nil)
+
+		backgroundColor = Colors.primaryBackground
+
+		hideSeparator()
+
+		decrementButton.addTarget(self, action: #selector(decrementValue), for: .touchUpInside)
+		incrementButton.addTarget(self, action: #selector(incrementValue), for: .touchUpInside)
+
+		contentView.addSubview(stepperControl)
+		contentView.addSubview(stepperLabel)
+
+		NSLayoutConstraint.activate([
+			stepperControl.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+			stepperControl.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
+
+			stepperLabel.centerYAnchor.constraint(equalTo: stepperControl.centerYAnchor),
+			stepperLabel.leadingAnchor.constraint(equalTo: stepperControl.trailingAnchor, constant: 16),
+			stepperLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16)
+		])
+
+		stepperLabel.text = initialRamSettting.label
+	}
+
+	required init?(coder: NSCoder) { fatalError() }
+
 	private static func makeStepButton(title: String) -> UIButton {
 		let button = UIButton(type: .system)
 		button.translatesAutoresizingMaskIntoConstraints = false
@@ -103,14 +136,6 @@ class PreferencesAdvancedRamStepperCell: UITableViewCell {
 		stepperLabel.text = ramSetting.label
 		didChangeStepperValue(ramSetting)
 	}
-#else
-	@objc private func stepperValueChanged() {
-		let stepperValue = Int(stepperControl.value)
-		let ramSetting = PreferencesGeneralRamSetting(rawValue: stepperValue) ?? .n256
-		stepperLabel.text = ramSetting.label
-		didChangeStepperValue(ramSetting)
-	}
-#endif
 }
 
 class PreferencesAdvancedMiscellaneousCell: UITableViewCell {

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Advanced/PreferencesAdvancedModel.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Advanced/PreferencesAdvancedModel.swift
@@ -32,6 +32,26 @@ class PreferencesAdvancedModel {
 	}
 
 	@MainActor
+	var clipboardSharingSetting: ClipboardSharingSetting {
+		get {
+			miscSettings.clipboardSharing
+		}
+		set {
+			miscSettings.set(clipboardSharing: newValue)
+		}
+	}
+
+	@MainActor
+	var reportClipboardSharingActivity: Bool {
+		get {
+			miscSettings.reportClipboardSharingActivity
+		}
+		set {
+			miscSettings.set(reportClipboardSharingActivity: newValue)
+		}
+	}
+
+	@MainActor
 	var fpsReportingEnabled: Bool {
 		get {
 			miscSettings.fpsReporting

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Advanced/PreferencesAdvancedViewController.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Advanced/PreferencesAdvancedViewController.swift
@@ -11,10 +11,11 @@ import Combine
 class PreferencesAdvancedViewController: PreferencesTableViewController {
 	enum Section {
 		case ramSetting
-		case performanceMetrics
-		case uiOptions
+		case clipboardSharing
 		case relateiveMouseMode
 		case relateiveMouseModeClickGesture
+		case performanceMetrics
+		case uiOptions
 		case hapticFeedback
 		case cpuEmulation
 		case bootstrap
@@ -25,14 +26,10 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 		//ramSetting
 		case ramSetting
 
-		//performanceMetrics
-		case performanceMetricsFpsCounterToggle
-		case performanceMetricsNetworkTransferRateToggle
-
-		//uiOptions
-		case uiOptionsHoverJustAbove
-		case uiOptionsAlwaysBootInLandscapeMode
-		case uiOptionsReportIpAddressAssignment
+		//clipboardSharing
+		case clipboardSharingOption(ClipboardSharingSetting)
+		case clipboardSharingMacToggle
+		case clipboardSharingInfo
 
 		//relateiveMouseMode
 		case relateiveMouseModeSetting
@@ -41,8 +38,18 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 		case relateiveMouseModeBootInfo
 
 		// relateiveMouseModeClickGesture
-		case relativeMouseModeClickGestureSetting(RelativeMouseModeClickGestureSetting)
+		case relativeMouseModeClickGestureOption(RelativeMouseModeClickGestureSetting)
 		case relativeMouseModeClickGestureSettingInfo
+
+		//performanceMetrics
+		case performanceMetricsFpsCounterToggle
+		case performanceMetricsNetworkTransferRateToggle
+
+		//uiOptions
+		case uiOptionsHoverJustAbove
+		case uiOptionsAlwaysBootInLandscapeMode
+		case uiOptionsReportIpAddressAssignment
+		case uiOptionsReportClipboardSharingActivity
 
 		// hapticFeedback
 		case hapticFeedbackSwipeGesturesToggle
@@ -119,13 +126,111 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 			guard let self else { return UITableViewCell() }
 			switch itemIdentifier {
 			case .ramSetting:
-				return PreferencesAdvancedRamStepperCell(
-					initialRamSettting: model.ramSetting
-				) { [weak self] newValue in
-					guard let self else { return }
-					model.ramSetting = newValue
-					feedbackGenerator.impactOccurred()
+				if UIDevice.deviceType == .mac {
+					return PreferencesAdvancedMacRamStepperCell(
+						initialRamSettting: model.ramSetting
+					) { [weak self] newValue in
+						guard let self else { return }
+						model.ramSetting = newValue
+						feedbackGenerator.impactOccurred()
+					}
+				} else {
+					return PreferencesAdvancedRamStepperCell(
+						initialRamSettting: model.ramSetting
+					) { [weak self] newValue in
+						guard let self else { return }
+						model.ramSetting = newValue
+						feedbackGenerator.impactOccurred()
+					}
 				}
+			case .clipboardSharingOption(let setting):
+				return PreferencesRadioButtonChoiceCell(
+					title: setting.label,
+					isSelected: setting == model.clipboardSharingSetting
+				)
+			case .clipboardSharingMacToggle:
+				return PreferencesEnabledSettingCell(
+					title: "Enable clipboard sharing",
+					isOn: model.clipboardSharingSetting == .automatic
+				) { [weak self] isOn in
+					guard let self else { return }
+					model.clipboardSharingSetting = isOn ? .automatic : .manual
+					dataSource.reloadItems([.clipboardSharingInfo])
+				}
+			case .clipboardSharingInfo:
+				return PreferencesInformationCell(
+					text: model.clipboardSharingSetting.infoString,
+					tagConfig: .init(
+						images: [
+							Assets.arrowRightPageOnClipboard.asSymbolImage(),
+							Assets.arrowLeftPageOnClipboard.asSymbolImage(),
+						]
+					)
+				)
+			case .relateiveMouseModeSetting:
+				return PreferencesAdvancedRelativeMouseModeSettingCell(
+					initialRelativeMouseModeSetting: model.relativeMouseModeSetting
+				) { [weak self] newFrameRateSetting in
+					guard let self else { return }
+					model.relativeMouseModeSetting = newFrameRateSetting
+					feedbackGenerator.impactOccurred()
+					reloadData()
+				}
+			case .relateiveMouseModeInfo(let relativeMouseModeSetting):
+				let duringEmulation = (model.mode == .startup) ? " during emulation" : ""
+				var toggleExplanation = ""
+				if relativeMouseModeSetting != .alwaysOn {
+					switch UIDevice.deviceType {
+					case .iPhone:
+						toggleExplanation = " Relative mouse mode can be toggled on and off\(duringEmulation) by tapping a <img/> button in a gamepad overlay."
+					case .iPad:
+						toggleExplanation = " Relative mouse mode can be toggled on and off\(duringEmulation) by tapping a <img/> button in a gamepad overlay. Alternatively by pressing option + F5, if using a hardware keyboard."
+					case .mac:
+						toggleExplanation = " Relative mouse mode can be toggled on and off\(duringEmulation) by pressing option + F5."
+					}
+				}
+				return PreferencesInformationCell(
+					text: "Some games and apps require relative mouse mode to function.\(toggleExplanation) <link>Read more</link>.",
+					tagConfig: .init(
+						images: [ImageResource.arrowUpAndDownAndArrowLeftAndRight.asSymbolImage()]
+					)
+				) { [weak self] in
+					guard let self else { return }
+					let vc = PreferencesRelativeMouseModeOnboardingViewController()
+					let navVC = UINavigationController()
+					navVC.viewControllers = [vc]
+
+					present(navVC, animated: true)
+				}
+			case .relateiveMouseModeBoot:
+				return PreferencesEnabledSettingCell(
+					title: "Boot with relative mouse mode on",
+					isOn: model.bootInRelativeMouseMode
+				) { [weak self] isOn in
+					self?.model.bootInRelativeMouseMode = isOn
+				}
+			case .relateiveMouseModeBootInfo:
+				return PreferencesInformationCell(
+					text: "Only has effect when input is set to Mouse."
+				)
+			case .relativeMouseModeClickGestureOption(let setting):
+				return PreferencesRadioButtonChoiceCell(
+					title: setting.label,
+					isSelected: setting == model.relativeMouseModeClickGestureSetting
+				)
+			case .relativeMouseModeClickGestureSettingInfo:
+				let text: String
+				switch model.relativeMouseModeClickGestureSetting {
+				case .off:
+					text = "Click can only be performed with Gamepad button."
+				case .tap:
+					text = "A quick tap induces mouse click."
+				case .secondFingerClick:
+					text = "A second finger control mouse down / up action while the first finger controls the position, as with two finger steering."
+				}
+				return PreferencesInformationCell(
+					text: text
+				)
 			case .performanceMetricsFpsCounterToggle:
 				return PreferencesEnabledSettingCell(
 					title: "Show FPS counter",
@@ -163,70 +268,13 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 				) { [weak self] isOn in
 					self?.model.reportIpAddressAssignment = isOn
 				}
-			case .relateiveMouseModeSetting:
-				return PreferencesAdvancedRelativeMouseModeSettingCell(
-					initialRelativeMouseModeSetting: model.relativeMouseModeSetting
-				) { [weak self] newFrameRateSetting in
-					guard let self else { return }
-					model.relativeMouseModeSetting = newFrameRateSetting
-					feedbackGenerator.impactOccurred()
-					reloadData()
-				}
-			case .relateiveMouseModeInfo(let relativeMouseModeSetting):
-				let duringEmulation = (model.mode == .startup) ? " during emulation" : ""
-				var toggleExplanation = ""
-				if relativeMouseModeSetting != .alwaysOn {
-					switch UIDevice.deviceType {
-					case .iPhone:
-						toggleExplanation = " Relative mouse mode can be toggled on and off\(duringEmulation) by tapping the <img/> button above the keyboard or as a gamepad button."
-					case .iPad:
-						toggleExplanation = " Relative mouse mode can be toggled on and off\(duringEmulation) by tapping the <img/> button above the software keyboard or as a gamepad button. Alternatively by pressing option + F5, if using a hardware keyboard."
-					case .mac:
-						toggleExplanation = " Relative mouse mode can be toggled on and off\(duringEmulation) by pressing option + F5."
-					}
-				}
-				return PreferencesInformationCell(
-					text: "Some games and apps require relative mouse mode to function.\(toggleExplanation) <link>Read more</link>.",
-					tagConfig: .init(
-						images: [ImageResource.arrowUpAndDownAndArrowLeftAndRight.asSymbolImage()]
-					)
-				) { [weak self] in
-					guard let self else { return }
-					let vc = PreferencesRelativeMouseModeOnboardingViewController()
-					let navVC = UINavigationController()
-					navVC.viewControllers = [vc]
-
-					present(navVC, animated: true)
-				}
-			case .relateiveMouseModeBoot:
+			case .uiOptionsReportClipboardSharingActivity:
 				return PreferencesEnabledSettingCell(
-					title: "Boot with relative mouse mode on",
-					isOn: model.bootInRelativeMouseMode
+					title: "Notify of clipboard sharing events",
+					isOn: model.reportClipboardSharingActivity
 				) { [weak self] isOn in
-					self?.model.bootInRelativeMouseMode = isOn
+					self?.model.reportClipboardSharingActivity = isOn
 				}
-			case .relateiveMouseModeBootInfo:
-				return PreferencesInformationCell(
-					text: "Only has effect when input is set to Mouse."
-				)
-			case .relativeMouseModeClickGestureSetting(let setting):
-				return PreferencesRadioButtonChoiceCell(
-					title: setting.label,
-					isSelected: setting == model.relativeMouseModeClickGestureSetting
-				)
-			case .relativeMouseModeClickGestureSettingInfo:
-				let text: String
-				switch model.relativeMouseModeClickGestureSetting {
-				case .off:
-					text = "Click can only be performed with Gamepad button."
-				case .tap:
-					text = "A quick tap induces mouse click."
-				case .secondFingerClick:
-					text = "A second finger control mouse down / up action while the first finger controls the position, as with two finger steering."
-				}
-				return PreferencesInformationCell(
-					text: text
-				)
 			case .hapticFeedbackSwipeGesturesToggle:
 				return PreferencesEnabledSettingCell(
 					title: "Two / three finger swipe gestures",
@@ -311,14 +359,16 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 			switch section {
 			case .ramSetting:
 				return "RAM setting"
-			case .performanceMetrics:
-				return "Performance metrics"
-			case .uiOptions:
-				return "UI options"
+			case .clipboardSharing:
+				return "Clipboard sharing"
 			case .relateiveMouseMode:
 				return "Relative mouse mode"
 			case .relateiveMouseModeClickGesture:
 				return "Relative mouse mode click gesture"
+			case .performanceMetrics:
+				return "Performance metrics"
+			case .uiOptions:
+				return "UI options"
 			case .hapticFeedback:
 				return "Haptic feedback"
 			case .cpuEmulation:
@@ -342,20 +392,18 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 		snapshot.appendSections([.ramSetting])
 		snapshot.appendItems([.ramSetting])
 
-		snapshot.appendSections([.performanceMetrics])
-		snapshot.appendItems([
-			.performanceMetricsFpsCounterToggle,
-			.performanceMetricsNetworkTransferRateToggle
-		])
 
-		snapshot.appendSections([.uiOptions])
-		if UIDevice.deviceType != .mac {
-			snapshot.appendItems([.uiOptionsHoverJustAbove])
-			if model.shouldDisplayAlwaysLandscapeModeOption {
-				snapshot.appendItems([.uiOptionsAlwaysBootInLandscapeMode])
-			}
+		snapshot.appendSections([.clipboardSharing])
+		switch UIDevice.deviceType {
+		case .mac:
+			snapshot.appendItems([.clipboardSharingMacToggle])
+		default:
+			snapshot.appendItems([
+				.clipboardSharingOption(ClipboardSharingSetting.manual),
+				.clipboardSharingOption(ClipboardSharingSetting.automatic)
+			])
 		}
-		snapshot.appendItems([.uiOptionsReportIpAddressAssignment])
+		snapshot.appendItems([.clipboardSharingInfo])
 
 		snapshot.appendSections([.relateiveMouseMode])
 		snapshot.appendItems([
@@ -381,11 +429,27 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 
 		if !model.isIPadMouseEnabled {
 			snapshot.appendSections([.relateiveMouseModeClickGesture])
-			snapshot.appendItems(RelativeMouseModeClickGestureSetting.allCases.map({.relativeMouseModeClickGestureSetting($0)}))
+			snapshot.appendItems(RelativeMouseModeClickGestureSetting.allCases.map({.relativeMouseModeClickGestureOption($0)}))
 			snapshot.appendItems([
 				.relativeMouseModeClickGestureSettingInfo
 			])
 		}
+
+		snapshot.appendSections([.performanceMetrics])
+		snapshot.appendItems([
+			.performanceMetricsFpsCounterToggle,
+			.performanceMetricsNetworkTransferRateToggle
+		])
+
+		snapshot.appendSections([.uiOptions])
+		if UIDevice.deviceType != .mac {
+			snapshot.appendItems([.uiOptionsHoverJustAbove])
+			if model.shouldDisplayAlwaysLandscapeModeOption {
+				snapshot.appendItems([.uiOptionsAlwaysBootInLandscapeMode])
+			}
+		}
+		snapshot.appendItems([.uiOptionsReportIpAddressAssignment])
+		snapshot.appendItems([.uiOptionsReportClipboardSharingActivity])
 
 		if model.supportsHaptics {
 			snapshot.appendSections([.hapticFeedback])
@@ -402,14 +466,12 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 			.altivec,
 			.altivecInfo
 		])
-		// The JIT requires Mac Catalyst: iOS forbids executable code pages,
-		// so the emulator core is built without the compiler there
-		#if targetEnvironment(macCatalyst)
-		snapshot.appendItems([
-			.jitCompiler,
-			.jitCompilerInfo
-		])
-		#endif
+		if UIDevice.deviceType == .mac {
+			snapshot.appendItems([
+				.jitCompiler,
+				.jitCompilerInfo
+			])
+		}
 
 		if model.hasRomFile {
 			snapshot.appendSections([.bootstrap])
@@ -490,9 +552,22 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 		tableView.endUpdates()
 	}
 
-	private func updateRelativeMouseModeClickGestureSettingCells() {
+	private func updateClipboardSharingOptionsCells() {
+		for setting in ClipboardSharingSetting.allCases {
+			guard let indexPath = dataSource.indexPath(for: .clipboardSharingOption(setting)),
+				  let cell = tableView.cellForRow(at: indexPath) as? PreferencesRadioButtonChoiceCell else {
+				continue
+			}
+
+			cell.configure(isSelected: setting == model.clipboardSharingSetting)
+		}
+
+		dataSource.reloadItems([.clipboardSharingInfo])
+	}
+
+	private func updateRelativeMouseModeClickGestureOptionsCells() {
 		for setting in RelativeMouseModeClickGestureSetting.allCases {
-			guard let indexPath = dataSource.indexPath(for: .relativeMouseModeClickGestureSetting(setting)),
+			guard let indexPath = dataSource.indexPath(for: .relativeMouseModeClickGestureOption(setting)),
 				  let cell = tableView.cellForRow(at: indexPath) as? PreferencesRadioButtonChoiceCell else {
 				continue
 			}
@@ -510,16 +585,14 @@ extension PreferencesAdvancedViewController { // UITableViewDataSource, UITableV
 		let sectionType = dataSource.sectionIdentifier(for: indexPath.section)
 		let itemIdentifier = dataSource.itemIdentifier(for: indexPath)
 
-		if sectionType == .resources {
+		switch (sectionType, itemIdentifier) {
+		case (.resources, _),
+			(.relateiveMouseModeClickGesture, .relativeMouseModeClickGestureOption),
+			(.clipboardSharing, .clipboardSharingOption):
 			return true
+		default:
+			return false
 		}
-
-		if sectionType == .relateiveMouseModeClickGesture,
-		   case .relativeMouseModeClickGestureSetting = itemIdentifier {
-			return true
-		}
-
-		return false
 	}
 
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -529,6 +602,22 @@ extension PreferencesAdvancedViewController { // UITableViewDataSource, UITableV
 		let itemIdentifier = dataSource.itemIdentifier(for: indexPath)
 
 		switch sectionType {
+		case .clipboardSharing:
+			switch itemIdentifier {
+			case .clipboardSharingOption(let setting):
+				model.clipboardSharingSetting = setting
+				updateClipboardSharingOptionsCells()
+			default:
+				fatalError()
+			}
+		case .relateiveMouseModeClickGesture:
+			switch itemIdentifier {
+			case .relativeMouseModeClickGestureOption(let setting):
+				model.relativeMouseModeClickGestureSetting = setting
+				updateRelativeMouseModeClickGestureOptionsCells()
+			default:
+				fatalError()
+			}
 		case .resources:
 			switch itemIdentifier {
 			case .resourcesSetupInstuctions:
@@ -561,14 +650,6 @@ extension PreferencesAdvancedViewController { // UITableViewDataSource, UITableV
 				navVC.viewControllers = [vc]
 
 				present(navVC, animated: true)
-			default:
-				fatalError()
-			}
-		case .relateiveMouseModeClickGesture:
-			switch itemIdentifier {
-			case .relativeMouseModeClickGestureSetting(let setting):
-				model.relativeMouseModeClickGestureSetting = setting
-				updateRelativeMouseModeClickGestureSettingCells()
 			default:
 				fatalError()
 			}
@@ -609,6 +690,29 @@ private extension RelativeMouseModeClickGestureSetting {
 		case .off: "Off"
 		case .tap: "Tap"
 		case .secondFingerClick: "Second finger click (recommended)"
+		}
+	}
+}
+
+private extension ClipboardSharingSetting {
+	var label: String {
+		switch self {
+		case .manual: "Manual"
+		case .automatic: "Automatic sharing"
+		}
+	}
+
+	var infoString: String {
+		let osLabel = UIDevice.deviceType.osLabel
+		switch self {
+		case .manual:
+			if UIDevice.deviceType == .mac {
+				return "Clipboard content will not be shared."
+			} else {
+				return "Clipboard content is copied between Classic Mac OS and \(osLabel) by pressing <img/> and <img/> buttons, located above software keyboard. Also available as gamepad overlay buttons."
+			}
+		case .automatic:
+			return "Clipboard content is automatically copied between Classic Mac OS and \(osLabel) after each copy action, in either OS."
 		}
 	}
 }

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Advanced/PreferencesAdvancedViewController.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Advanced/PreferencesAdvancedViewController.swift
@@ -27,7 +27,6 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 
 		//performanceMetrics
 		case performanceMetricsFpsCounterToggle
-		case performanceMetricsFpsCounterInfo
 		case performanceMetricsNetworkTransferRateToggle
 
 		//uiOptions
@@ -134,11 +133,6 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 				) { [weak self] isOn in
 					self?.model.fpsReportingEnabled = isOn
 				}
-			case .performanceMetricsFpsCounterInfo:
-				return PreferencesInformationCell(
-					text: "PocketShaver only renders frames when there are visual changes. Therefore, low FPS count does not always mean low performace.",
-					separatorHidden: false
-				)
 			case .performanceMetricsNetworkTransferRateToggle:
 				return PreferencesEnabledSettingCell(
 					title: "Show network transfer rate",
@@ -351,7 +345,6 @@ class PreferencesAdvancedViewController: PreferencesTableViewController {
 		snapshot.appendSections([.performanceMetrics])
 		snapshot.appendItems([
 			.performanceMetricsFpsCounterToggle,
-			.performanceMetricsFpsCounterInfo,
 			.performanceMetricsNetworkTransferRateToggle
 		])
 

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Graphics/PreferencesGraphicsViewController.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Graphics/PreferencesGraphicsViewController.swift
@@ -11,9 +11,9 @@ class PreferencesGraphicsViewController: PreferencesTableViewController {
 		case display
 		case frameRateSetting
 		case monitorResolutions
+		case graphicsAcceleration
 		case rendering
 		case gammaRampSetting
-		case graphicsAcceleration
 	}
 
 	enum Row: Hashable {
@@ -29,6 +29,13 @@ class PreferencesGraphicsViewController: PreferencesTableViewController {
 		case monitorResolutions(PreferencesGraphicsModel.MonitorResolutionsState)
 		case monitorResolutionsInformation(Bool)
 
+		// graphicsAcceleration
+		case graphicsAccelerationNqdToggle
+		case graphicsAccelerationRaveToggle
+		case graphicsAccelerationGlToggle
+		case graphicsAccelerationDspToggle
+		case graphicsAccelerationInfo
+
 		// rendering
 		case renderingFilterMode
 		case renderingFilterModeInfo
@@ -36,13 +43,6 @@ class PreferencesGraphicsViewController: PreferencesTableViewController {
 		// gammaRampSetting
 		case gammaRampSetting
 		case gammaRampSettingInfo
-
-		// graphicsAcceleration
-		case graphicsAccelerationNqdToggle
-		case graphicsAccelerationRaveToggle
-		case graphicsAccelerationGlToggle
-		case graphicsAccelerationDspToggle
-		case graphicsAccelerationInfo
 	}
 
 	private let model: PreferencesGraphicsModel
@@ -160,6 +160,38 @@ class PreferencesGraphicsViewController: PreferencesTableViewController {
 				return PreferencesInformationCell(
 					text: text
 				)
+			case .graphicsAccelerationNqdToggle:
+				return PreferencesEnabledSettingCell(
+					title: "QuickDraw 2D",
+					isOn: model.nqdAccelEnabled
+				) { [weak self] isOn in
+					self?.model.nqdAccelEnabled = isOn
+				}
+			case .graphicsAccelerationRaveToggle:
+				return PreferencesEnabledSettingCell(
+					title: "QuickDraw 3D + RAVE",
+					isOn: model.raveAccelEnabled
+				) { [weak self] isOn in
+					self?.model.raveAccelEnabled = isOn
+				}
+			case .graphicsAccelerationGlToggle:
+				return PreferencesEnabledSettingCell(
+					title: "OpenGL",
+					isOn: model.glAccelEnabled
+				) { [weak self] isOn in
+					self?.model.glAccelEnabled = isOn
+				}
+			case .graphicsAccelerationDspToggle:
+				return PreferencesEnabledSettingCell(
+					title: "DrawSprocket",
+					isOn: model.dspAccelEnabled
+				) { [weak self] isOn in
+					self?.model.dspAccelEnabled = isOn
+				}
+			case .graphicsAccelerationInfo:
+				return PreferencesCardInformationCell(
+					text: "Each accelerator is independent — mix and match per app to find what runs best."
+				)
 			case .displayMode:
 				return PreferencesGraphicsDisplayModeCell(
 					initialDisplayMode: model.displayMode
@@ -194,40 +226,7 @@ class PreferencesGraphicsViewController: PreferencesTableViewController {
 				}
 			case .gammaRampSettingInfo:
 				return PreferencesInformationCell(
-					text: "Linear gamma ramp generally produces a darker, but less color distorted image. Higher screen brightness can compensate for the darkness and, in some instances, produce a higher color dynamic. Takes effect on next resolution change or restart."
-				)
-
-			case .graphicsAccelerationNqdToggle:
-				return PreferencesEnabledSettingCell(
-					title: "Quick Draw 2D Acceleration",
-					isOn: model.nqdAccelEnabled
-				) { [weak self] isOn in
-					self?.model.nqdAccelEnabled = isOn
-				}
-			case .graphicsAccelerationRaveToggle:
-				return PreferencesEnabledSettingCell(
-					title: "QuickDraw 3D + RAVE Acceleration",
-					isOn: model.raveAccelEnabled
-				) { [weak self] isOn in
-					self?.model.raveAccelEnabled = isOn
-				}
-			case .graphicsAccelerationGlToggle:
-				return PreferencesEnabledSettingCell(
-					title: "OpenGL Acceleration",
-					isOn: model.glAccelEnabled
-				) { [weak self] isOn in
-					self?.model.glAccelEnabled = isOn
-				}
-			case .graphicsAccelerationDspToggle:
-				return PreferencesEnabledSettingCell(
-					title: "DrawSprocket Acceleration",
-					isOn: model.dspAccelEnabled
-				) { [weak self] isOn in
-					self?.model.dspAccelEnabled = isOn
-				}
-			case .graphicsAccelerationInfo:
-				return PreferencesInformationCell(
-					text: "Experimental. Each accelerator is independent — mix and match per app to find what runs best. All four default on. Requires Metal; takes effect on restart."
+					text: "Linear gamma ramp generally produces a less color distorted image. Higher screen brightness can compensate for a potentially dark picture and, in some instances, produce a higher color dynamic. Takes effect on next resolution change or restart."
 				)
 			}
 		}
@@ -240,12 +239,13 @@ class PreferencesGraphicsViewController: PreferencesTableViewController {
 				return "Frame rate setting"
 			case .monitorResolutions:
 				return "Monitor resolutions"
+			case .graphicsAcceleration:
+				return "Graphics acceleration (experimental)"
 			case .rendering:
 				return "Rendering filter"
 			case .gammaRampSetting:
 				return "Gamma ramp"
-			case .graphicsAcceleration:
-				return "Graphics acceleration"
+
 			}
 		}
 
@@ -258,13 +258,13 @@ class PreferencesGraphicsViewController: PreferencesTableViewController {
 	private func reloadData() {
 		var snapshot = NSDiffableDataSourceSnapshot<Section, Row>()
 
-		#if targetEnvironment(macCatalyst)
-		snapshot.appendSections([.display])
-		snapshot.appendItems([
-			.displayMode,
-			.displayModeInfo
-		])
-		#endif
+		if UIDevice.deviceType == .mac {
+			snapshot.appendSections([.display])
+			snapshot.appendItems([
+				.displayMode,
+				.displayModeInfo
+			])
+		}
 
 		if UIScreen.supportsHighRefreshRate {
 			snapshot.appendSections([.frameRateSetting])
@@ -281,6 +281,15 @@ class PreferencesGraphicsViewController: PreferencesTableViewController {
 			.monitorResolutionsInformation(model.monitorResolutionsState.willBootFromCD)
 		])
 
+		snapshot.appendSections([.graphicsAcceleration])
+		snapshot.appendItems([
+			.graphicsAccelerationNqdToggle,
+			.graphicsAccelerationRaveToggle,
+			.graphicsAccelerationGlToggle,
+			.graphicsAccelerationDspToggle,
+			.graphicsAccelerationInfo
+		])
+
 		snapshot.appendSections([.rendering])
 		snapshot.appendItems([
 			.renderingFilterMode,
@@ -291,15 +300,6 @@ class PreferencesGraphicsViewController: PreferencesTableViewController {
 		snapshot.appendItems([
 			.gammaRampSetting,
 			.gammaRampSettingInfo
-		])
-
-		snapshot.appendSections([.graphicsAcceleration])
-		snapshot.appendItems([
-			.graphicsAccelerationNqdToggle,
-			.graphicsAccelerationRaveToggle,
-			.graphicsAccelerationGlToggle,
-			.graphicsAccelerationDspToggle,
-			.graphicsAccelerationInfo
 		])
 
 		dataSource.apply(snapshot)

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Onboardings/Relative mouse mode/PreferencesRelativeMouseModeOnboarding.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Onboardings/Relative mouse mode/PreferencesRelativeMouseModeOnboarding.swift
@@ -40,9 +40,9 @@ class PreferencesRelativeMouseModeOnboardingCell: UITableViewCell {
 		let toggleOnText: String
 		switch UIDevice.deviceType {
 		case .iPhone:
-			toggleOnText = "By the <img/> button, located on top of the software keyboard. The software keyboard is accessed by swiping up with three fingers.\nThis button can also be added to a gamepad and toggled from there."
+			toggleOnText = "By a <img/> button (relative mouse mode toggle button), located in a gamepad overlay. Gamepad overlays can be accessed by swiping down with three fingers during emulation. The provided Example FPS overlay has this button, but you can edit or create new gamepad overlays to adapt to your needs."
 		case .iPad:
-			toggleOnText = "By the <img/> button, located on top of the software keyboard. The software keyboard is accessed by swiping up with three fingers.\nThis button can also be added to a gamepad and toggled from there.\nAlternatively, you can toggle it by pressing option + F5, if using a hardware keyboard."
+			toggleOnText = "By a <img/> button (relative mouse mode toggle button), located in a gamepad overlay. Gamepad overlays can be accessed by swiping down with three fingers during emulation. The provided Example FPS overlay has this button, but you can edit or create new gamepad overlays to adapt to your needs.\nAlternatively, you can toggle it by pressing option + F5, if using a hardware keyboard."
 		case .mac:
 			toggleOnText = "By pressing option + F5 (during emulation)."
 		}
@@ -51,7 +51,7 @@ class PreferencesRelativeMouseModeOnboardingCell: UITableViewCell {
 
 <mark>How do I steer with relative mouse mode on?</mark>
 
-When using bluetooth mouse on iPad, just use the mouse normally.
+When using bluetooth mouse on iPad or Mac, just use the mouse normally.
 When using touch input on iPhone or iPad, the mouse can be steered by either simply dragging with one finger or by mouse joystick in Gamepad mode.
 """
 

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Shared UI/TableViewDiffableDataSource.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Preferences/Shared UI/TableViewDiffableDataSource.swift
@@ -7,24 +7,17 @@
 
 import UIKit
 
+
+#if targetEnvironment(macCatalyst)
 /// Shared base for the preferences table screens. The stock plain-style
 /// section headers are small and pale, which on the full-screen Mac window
 /// makes each tab read as one undifferentiated list — replace them with big
-/// bold full-contrast headings there. iPhone/iPad keep the stock look.
+/// bold full-contrast headings there.
 ///
 /// The header view is built from scratch rather than restyled: UIKit renders
 /// the stock header title through a content configuration it re-applies after
 /// `willDisplay`, so font/color set on its `textLabel` does not survive.
 class PreferencesTableViewController: UITableViewController {
-	private func macSectionTitle(_ tableView: UITableView, _ section: Int) -> String? {
-		guard UIDevice.deviceType == .mac,
-			  let title = tableView.dataSource?.tableView?(tableView, titleForHeaderInSection: section),
-			  !title.isEmpty else {
-			return nil
-		}
-		return title
-	}
-
 	private func sectionHasTitle(_ tableView: UITableView, _ section: Int) -> Bool {
 		guard let title = tableView.dataSource?.tableView?(tableView, titleForHeaderInSection: section) else {
 			return false
@@ -33,8 +26,9 @@ class PreferencesTableViewController: UITableViewController {
 	}
 
 	override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-		guard let title = macSectionTitle(tableView, section) else {
-			return nil // stock header (and collapsed untitled sections)
+		guard let title = tableView.dataSource?.tableView?(tableView, titleForHeaderInSection: section),
+			  !title.isEmpty else {
+			return nil
 		}
 
 		let header = UIView()
@@ -63,9 +57,14 @@ class PreferencesTableViewController: UITableViewController {
 			return .leastNonzeroMagnitude
 		}
 
-		return UIDevice.deviceType == .mac ? 52 : UITableView.automaticDimension
+		return 52
 	}
 }
+#else // targetEnvironment(macCatalyst)
+
+typealias PreferencesTableViewController = UITableViewController
+
+#endif
 
 class TableViewDiffableDataSource<T: Hashable, S: Hashable> : UITableViewDiffableDataSource<T, S> {
 	var sectionTitleProvider: ((T) -> String?)?

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Resources/Assets.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Resources/Assets.swift
@@ -39,4 +39,12 @@ enum Assets {
 	static var arrowRightArrowLeft: UIImage {
 		.init(systemName: "arrow.right.arrow.left")!
 	}
+
+	static var arrowLeftPageOnClipboard: UIImage {
+		.init(named: "arrow.left.page.on.clipboard")!
+	}
+
+	static var arrowRightPageOnClipboard: UIImage {
+		.init(named: "arrow.right.page.on.clipboard")!
+	}
 }

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Resources/Assets.xcassets/arrow.left.page.on.clipboard.symbolset/Contents.json
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Resources/Assets.xcassets/arrow.left.page.on.clipboard.symbolset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "filename" : "arrow.left.page.on.clipboard.svg",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Resources/Assets.xcassets/arrow.left.page.on.clipboard.symbolset/arrow.left.page.on.clipboard.svg
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Resources/Assets.xcassets/arrow.left.page.on.clipboard.symbolset/arrow.left.page.on.clipboard.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Generator: Apple Native CoreSVG 341-->
+<!DOCTYPE svg
+PUBLIC "-//W3C//DTD SVG 1.1//EN"
+       "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3300 2200">
+ <!--glyph: "10193B", point size: 100.0, font version: "20.0d10e1", template writer version: "138.0.0"-->
+ <style>.defaults {-sfsymbols-wiggle-style:linear;-sfsymbols-wiggle-angle:0}
+
+.monochrome-0 {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.monochrome-1 {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.monochrome-2 {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.monochrome-3 {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+
+.multicolor-0:tintColor {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.multicolor-1:tintColor {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.multicolor-2:tintColor {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.multicolor-3:tintColor {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+
+.hierarchical-0:secondary {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.hierarchical-1:primary {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.hierarchical-2:primary {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.hierarchical-3:primary {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+
+.SFSymbolsPreviewWireframe {fill:none;opacity:1.0;stroke:black;stroke-width:0.5}
+</style>
+ <g id="Notes">
+  <rect height="2200" id="artboard" style="fill:white;opacity:1" width="3300" x="0" y="0"/>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="292" y2="292"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 322)">Weight/Scale Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 559.711 322)">Ultralight</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 856.422 322)">Thin</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1153.13 322)">Light</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1449.84 322)">Regular</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1746.56 322)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2043.27 322)">Semibold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2339.98 322)">Bold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2636.69 322)">Heavy</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2933.4 322)">Black</text>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1903" y2="1903"/>
+  <g transform="matrix(0.2 0 0 0.2 263 1933)">
+   <path d="m46.2402 4.15039c21.7773 0 39.4531-17.627 39.4531-39.4043s-17.6758-39.4043-39.4531-39.4043c-21.7285 0-39.4043 17.627-39.4043 39.4043s17.6758 39.4043 39.4043 39.4043Zm0-7.42188c-17.6758 0-31.9336-14.3066-31.9336-31.9824s14.2578-31.9824 31.9336-31.9824 31.9824 14.3066 31.9824 31.9824-14.3066 31.9824-31.9824 31.9824Zm-17.9688-31.9824c0 2.14844 1.51367 3.61328 3.75977 3.61328h10.498v10.5957c0 2.19727 1.46484 3.71094 3.61328 3.71094 2.24609 0 3.71094-1.51367 3.71094-3.71094v-10.5957h10.5957c2.19727 0 3.71094-1.46484 3.71094-3.61328 0-2.19727-1.51367-3.71094-3.71094-3.71094h-10.5957v-10.5469c0-2.24609-1.46484-3.75977-3.71094-3.75977-2.14844 0-3.61328 1.51367-3.61328 3.75977v10.5469h-10.498c-2.24609 0-3.75977 1.51367-3.75977 3.71094Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 281.506 1933)">
+   <path d="m58.5449 14.5508c27.4902 0 49.8047-22.3145 49.8047-49.8047s-22.3145-49.8047-49.8047-49.8047-49.8047 22.3145-49.8047 49.8047 22.3145 49.8047 49.8047 49.8047Zm0-8.30078c-22.9492 0-41.5039-18.5547-41.5039-41.5039s18.5547-41.5039 41.5039-41.5039 41.5039 18.5547 41.5039 41.5039-18.5547 41.5039-41.5039 41.5039Zm-22.6562-41.5039c0 2.39258 1.66016 4.00391 4.15039 4.00391h14.3555v14.4043c0 2.44141 1.66016 4.15039 4.05273 4.15039 2.44141 0 4.15039-1.66016 4.15039-4.15039v-14.4043h14.4043c2.44141 0 4.15039-1.61133 4.15039-4.00391 0-2.44141-1.70898-4.15039-4.15039-4.15039h-14.4043v-14.3555c0-2.49023-1.70898-4.19922-4.15039-4.19922-2.39258 0-4.05273 1.70898-4.05273 4.19922v14.3555h-14.3555c-2.49023 0-4.15039 1.70898-4.15039 4.15039Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 304.924 1933)">
+   <path d="m74.8535 28.3203c35.1074 0 63.623-28.4668 63.623-63.5742s-28.5156-63.623-63.623-63.623-63.5742 28.5156-63.5742 63.623 28.4668 63.5742 63.5742 63.5742Zm0-9.08203c-30.127 0-54.4922-24.3652-54.4922-54.4922s24.3652-54.4922 54.4922-54.4922 54.4922 24.3652 54.4922 54.4922-24.3652 54.4922-54.4922 54.4922Zm-28.8574-54.4922c0 2.58789 1.85547 4.39453 4.58984 4.39453h19.7266v19.7754c0 2.68555 1.85547 4.58984 4.44336 4.58984 2.68555 0 4.54102-1.85547 4.54102-4.58984v-19.7754h19.7754c2.68555 0 4.58984-1.80664 4.58984-4.39453 0-2.73438-1.85547-4.58984-4.58984-4.58984h-19.7754v-19.7266c0-2.73438-1.85547-4.63867-4.54102-4.63867-2.58789 0-4.44336 1.9043-4.44336 4.63867v19.7266h-19.7266c-2.73438 0-4.58984 1.85547-4.58984 4.58984Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 1953)">Design Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1971)">Symbols are supported in up to nine weights and three scales.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1989)">For optimal layout with text and other symbols, vertically align</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 2007)">symbols with the adjacent text.</text>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="776" x2="776" y1="1919" y2="1933"/>
+  <g transform="matrix(0.2 0 0 0.2 776 1933)">
+   <path d="m16.5527 0.78125c2.58789 0 3.85742-0.976562 4.78516-3.71094l6.29883-17.2363h28.8086l6.29883 17.2363c0.927734 2.73438 2.19727 3.71094 4.73633 3.71094 2.58789 0 4.24805-1.5625 4.24805-4.00391 0-0.830078-0.146484-1.61133-0.537109-2.63672l-22.9004-60.9863c-1.12305-2.97852-3.125-4.49219-6.25-4.49219-3.02734 0-5.07812 1.46484-6.15234 4.44336l-22.9004 61.084c-0.390625 1.02539-0.537109 1.80664-0.537109 2.63672 0 2.44141 1.5625 3.95508 4.10156 3.95508Zm13.4766-28.3691 11.8652-32.8613h0.244141l11.8652 32.8613Z"/>
+  </g>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="792.836" x2="792.836" y1="1919" y2="1933"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 776 1953)">Margins</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1971)">Leading and trailing margins on the left and right side of each symbol</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1989)">can be adjusted by modifying the x-location of the margin guidelines.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2007)">Modifications are automatically applied proportionally to all</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2025)">scales and weights.</text>
+  <g transform="matrix(0.2 0 0 0.2 1289 1933)">
+   <path d="m14.209 9.32617 8.49609 8.54492c4.29688 4.3457 9.22852 4.05273 13.8672-1.07422l53.4668-58.9355-4.83398-4.88281-53.0762 58.3984c-1.75781 2.00195-3.41797 2.49023-5.76172 0.146484l-5.85938-5.81055c-2.34375-2.29492-1.80664-4.00391 0.195312-5.81055l57.373-54.0039-4.88281-4.83398-57.959 54.4434c-4.93164 4.58984-5.32227 9.47266-1.02539 13.8184Zm32.0801-90.9668c-2.09961 2.05078-2.24609 4.93164-1.07422 6.88477 1.17188 1.80664 3.4668 2.97852 6.68945 2.14844 7.32422-1.70898 14.9414-2.00195 22.0703 2.68555l-2.92969 7.27539c-1.70898 4.15039-0.830078 7.08008 1.85547 9.81445l11.4746 11.5723c2.44141 2.44141 4.49219 2.53906 7.32422 2.05078l5.32227-0.976562 3.32031 3.36914-0.195312 2.7832c-0.195312 2.49023 0.439453 4.39453 2.88086 6.78711l3.80859 3.71094c2.39258 2.39258 5.46875 2.53906 7.8125 0.195312l14.5508-14.5996c2.34375-2.34375 2.24609-5.32227-0.146484-7.71484l-3.85742-3.80859c-2.39258-2.39258-4.24805-3.17383-6.64062-2.97852l-2.88086 0.244141-3.22266-3.17383 1.2207-5.61523c0.634766-2.83203-0.146484-5.0293-3.07617-7.95898l-10.9863-10.9375c-16.6992-16.6016-38.8672-16.2109-53.3203-1.75781Zm7.4707 1.85547c12.1582-8.88672 28.6133-7.37305 39.7461 3.75977l12.1582 12.0605c1.17188 1.17188 1.36719 2.09961 1.02539 3.80859l-1.61133 7.42188 7.51953 7.42188 4.93164-0.292969c1.26953-0.0488281 1.66016 0.0488281 2.63672 1.02539l2.88086 2.88086-12.207 12.207-2.88086-2.88086c-0.976562-0.976562-1.12305-1.36719-1.07422-2.68555l0.341797-4.88281-7.4707-7.42188-7.61719 1.26953c-1.61133 0.341797-2.34375 0.195312-3.56445-0.976562l-10.0098-10.0098c-1.26953-1.17188-1.41602-2.00195-0.634766-3.85742l4.39453-10.4492c-7.8125-7.27539-17.9688-10.4004-28.125-7.42188-0.78125 0.195312-1.07422-0.439453-0.439453-0.976562Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 1289 1953)">Exporting</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1971)">Symbols should be outlined when exporting to ensure the</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1989)">design is preserved when submitting to Xcode.</text>
+  <text id="template-version" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1933)">Template v.6.0</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1951)">Requires Xcode 16 or greater</text>
+  <text id="descriptive-name" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1969)">Generated from arrow.right.page.on.clipboard</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1987)">Typeset at 100.0 points</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 726)">Small</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1156)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1586)">Large</text>
+ </g>
+ <g id="Guides">
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 696)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="696" y2="696"/>
+  <line id="Capline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="625.541" y2="625.541"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1126)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1126" y2="1126"/>
+  <line id="Capline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1055.54" y2="1055.54"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1556)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1556" y2="1556"/>
+  <line id="Capline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1485.54" y2="1485.54"/>
+  <line id="right-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2986.33" x2="2986.33" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2880.47" x2="2880.47" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1498.99" x2="1498.99" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1400.7" x2="1400.7" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="607.426" x2="607.426" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="511.996" x2="511.996" y1="600.785" y2="720.121"/>
+ </g>
+ <g id="Symbols">
+  <g id="Black-S" transform="matrix(1 0 0 1 2880.47 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M30.5664-71.2891L30.5664-21.3867C30.5664-11.8164 36.2305-6.15234 45.8008-6.15234L80.8594-6.15234C90.4297-6.15234 96.0938-11.8164 96.0938-21.3867L96.0938-71.2891C96.0938-80.8594 90.4297-86.5234 80.8594-86.5234L45.8008-86.5234C36.2305-86.5234 30.5664-80.8594 30.5664-71.2891ZM55.7129-69.9707C53.9062-69.9707 52.4414-71.5332 52.4414-73.2422L52.4414-74.3164C52.4414-75.4395 53.5156-77.5879 55.7129-77.5879L70.9961-77.5879C73.1934-77.5879 74.2676-75.4395 74.2676-74.3164L74.2676-73.2422C74.2676-71.5332 72.7539-69.9707 70.9961-69.9707Z"/>
+   <path class="monochrome-1 monochrome-2 multicolor-1:tintColor multicolor-2:tintColor hierarchical-1:primary hierarchical-2:primary SFSymbolsPreviewWireframe" d="M9.76562 0.878906C9.76562 10.4492 15.4297 16.1133 25 16.1133L60.0586 16.1133C69.6289 16.1133 75.293 10.4492 75.293 0.878906L75.293-49.0234C75.293-58.5938 69.6289-64.2578 60.0586-64.2578L25-64.2578C15.4297-64.2578 9.76562-58.5938 9.76562-49.0234Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:primary SFSymbolsPreviewWireframe" d="M23.9258-1.36719L23.9258-46.7773C23.9258-49.0234 24.8047-50.0977 27.2461-50.0977L57.8125-50.0977C60.2539-50.0977 61.1328-49.0234 61.1328-46.7773L61.1328-1.36719C61.1328 0.878906 60.2539 1.95312 57.8125 1.95312L27.2461 1.95312C24.8047 1.95312 23.9258 0.878906 23.9258-1.36719Z"/>
+   <path class="monochrome-3 multicolor-3:tintColor hierarchical-3:primary SFSymbolsPreviewWireframe" d="M27.2934 -24.0723 C 27.2934 -25.3418 27.7328 -26.6602 28.9047 -27.9297 L 38.0844 -37.5 C 38.8168 -38.2324 39.598 -38.6719 40.7699 -38.6719 C 42.9672 -38.6719 44.4809 -36.6699 44.4809 -34.8145 C 44.4809 -33.5938 43.9438 -32.6172 43.1625 -31.8848 L 40.5258 -29.3457 L 37.9379 -28.2715 L 42.1859 -28.7109 L 53.7582 -28.7109 C 56.2484 -28.7109 58.348 -26.6602 58.348 -24.0723 C 58.348 -21.4355 56.2484 -19.4336 53.7582 -19.4336 L 42.1859 -19.4336 L 37.9379 -19.873 L 40.5258 -18.7988 L 43.1625 -16.2598 C 43.9438 -15.5273 44.4809 -14.5508 44.4809 -13.3301 C 44.4809 -11.4746 42.9672 -9.4727 40.7699 -9.4727 C 39.598 -9.4727 38.8168 -9.9121 38.0844 -10.6445 L 28.9047 -20.2148 C 27.7328 -21.4844 27.2934 -22.8027 27.2934 -24.0723Z"/>
+  </g>
+  <g id="Regular-S" transform="matrix(1 0 0 1 1400.7 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M28.3203-71.2891L28.3203-18.75C28.3203-10.4492 32.373-6.29883 40.5762-6.29883L76.2207-6.29883C84.4238-6.29883 88.5254-10.4492 88.5254-18.75L88.5254-71.2891C88.5254-79.6387 84.4238-83.7402 76.2207-83.7402L40.5762-83.7402C32.373-83.7402 28.3203-79.6387 28.3203-71.2891ZM48.8281-70.1172C47.0703-70.1172 46.2402-71.2891 46.2402-72.5098L46.2402-73.3887C46.2402-74.6094 47.0703-75.7812 48.8281-75.7812L68.0176-75.7812C69.7754-75.7812 70.6055-74.6094 70.6055-73.3887L70.6055-72.5098C70.6055-71.2891 69.7754-70.1172 68.0176-70.1172Z"/>
+   <path class="monochrome-1 monochrome-2 multicolor-1:tintColor multicolor-2:tintColor hierarchical-1:primary hierarchical-2:primary SFSymbolsPreviewWireframe" d="M9.76562 0.683594C9.76562 9.0332 13.8184 13.1348 22.0215 13.1348L57.666 13.1348C65.8691 13.1348 69.9707 8.98438 69.9707 0.683594L69.9707-51.8555C69.9707-60.1562 65.8691-64.3066 57.666-64.3066L22.0215-64.3066C13.8184-64.3066 9.76562-60.2051 9.76562-51.8555Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:primary SFSymbolsPreviewWireframe" d="M16.7969 0.585938L16.7969-51.7578C16.7969-55.2734 18.7012-57.2754 22.3633-57.2754L57.3242-57.2754C60.9863-57.2754 62.8906-55.2734 62.8906-51.7578L62.8906 0.585938C62.8906 4.10156 60.9863 6.10352 57.3242 6.10352L22.3633 6.10352C18.7012 6.10352 16.7969 4.10156 16.7969 0.585938Z"/>
+   <path class="monochrome-3 multicolor-3:tintColor hierarchical-3:primary SFSymbolsPreviewWireframe" d="M23.687 -25.5859 C 23.687 -26.3184 23.9799 -27.0508 24.7124 -27.832 L 34.478 -38.0371 C 35.0151 -38.623 35.6499 -38.9648 36.5288 -38.9648 C 38.0913 -38.9648 39.312 -37.7441 39.312 -36.1328 C 39.312 -35.4004 38.9702 -34.5703 38.3354 -33.9844 L 33.5502 -29.6387 L 32.3784 -28.5156 L 36.4311 -28.7109 L 52.644 -29 C 54.4975 -28.7109 55.9135 -27.2461 55.9135 -25.5859 C 55.9135 -23.9258 54.4975 -22.4609 52.8862 -22.4609 L 36.4311 -22.4609 L 32.3784 -22.6562 L 33.5502 -21.5332 L 38.3354 -17.1875 C 38.9702 -16.6016 39.312 -15.8203 39.312 -15.0879 C 39.312 -13.4766 38.0913 -12.207 36.5288 -12.207 C 35.6499 -12.207 35.0151 -12.5977 34.478 -13.1348 L 24.7124 -23.3398 C 23.9799 -24.1211 23.687 -24.8535 23.644 -26Z"/>
+  </g>
+  <g id="Ultralight-S" transform="matrix(1 0 0 1 511.996 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M28.2749-71.9248L28.2749-16.1616C28.2749-9.63184 31.7373-6.1626 38.2603-6.1626L75.6758-6.1626C82.1987-6.1626 85.6646-9.63184 85.6646-16.1616L85.6646-71.9248C85.6646-78.458 82.1987-81.9238 75.6758-81.9238L38.2603-81.9238C31.7373-81.9238 28.2749-78.458 28.2749-71.9248ZM48.7827-71.0708C47.5698-71.0708 46.9668-71.8794 46.9668-72.6914L46.9668-73.2979C46.9668-74.1099 47.5698-74.9185 48.7827-74.9185L65.1568-74.9185C66.3242-74.9185 66.9273-74.1099 66.9273-73.2979L66.9273-72.6914C66.9273-71.8794 66.3242-71.0708 65.1568-71.0708Z"/>
+   <path class="monochrome-1 monochrome-2 multicolor-1:tintColor multicolor-2:tintColor hierarchical-1:primary hierarchical-2:primary SFSymbolsPreviewWireframe" d="M9.76562 1.41015C9.76562 7.94337 13.228 11.4092 19.751 11.4092L57.1665 11.4092C63.6895 11.4092 67.1553 7.98536 67.1553 1.41015L67.1553-54.353C67.1553-60.8828 63.6895-64.3521 57.1665-64.3521L19.751-64.3521C13.228-64.3521 9.76562-60.8862 9.76562-54.353Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:primary SFSymbolsPreviewWireframe" d="M11.9834 1.31249L11.9834-54.2554C11.9834-59.4511 14.6597-62.1342 19.8657-62.1342L57.0518-62.1342C62.2578-62.1342 64.9341-59.4511 64.9341-54.2554L64.9341 1.31249C64.9341 6.50828 62.2578 9.19138 57.0518 9.19138L19.8657 9.19138C14.6597 9.19138 11.9834 6.50828 11.9834 1.31249Z"/>
+   <path class="monochrome-3 multicolor-3:tintColor hierarchical-3:primary SFSymbolsPreviewWireframe" d="M22.0441 -26.4487 C 22.0441 -26.727 22.1554 -27.0054 22.3429 -27.2417 L 34.0158 -38.8545 C 34.235 -39.1226 34.5065 -39.1919 34.7043 -39.1919 C 35.2678 -39.1919 35.7619 -38.7432 35.7619 -38.2217 C 35.7619 -37.9887 35.6472 -37.6128 35.3757 -37.4355 L 28.2746 -30.3652 L 25.4226 -27.5166 L 29.884 -27.5303 L 54.6037 -27.5303 C 55.1706 -27.5303 55.6784 -27.0645 55.32 -26 C 55.6784 -25.8784 55.1706 -25.3672 54.6037 -25.3672 L 29.884 -25.3672 L 25.468 -25.4262 L 28.2746 -22.623 L 35.3757 -15.5527 C 35.6472 -15.3301 35.7619 -15.0029 35.7619 -14.77 C 35.7619 -14.2485 35.2678 -13.7964 34.7043 -13.7964 C 34.5065 -13.7964 34.235 -13.8691 34.0158 -14.0884 L 22.3429 -25.7012 C 22.1554 -25.9375 22.32 -27 22.0441 -26.4487Z"/>
+  </g>
+ </g>
+</svg>

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Resources/Assets.xcassets/arrow.right.page.on.clipboard.symbolset/Contents.json
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Resources/Assets.xcassets/arrow.right.page.on.clipboard.symbolset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "filename" : "arrow.right.page.on.clipboard.svg",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Resources/Assets.xcassets/arrow.right.page.on.clipboard.symbolset/arrow.right.page.on.clipboard.svg
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Resources/Assets.xcassets/arrow.right.page.on.clipboard.symbolset/arrow.right.page.on.clipboard.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Generator: Apple Native CoreSVG 341-->
+<!DOCTYPE svg
+PUBLIC "-//W3C//DTD SVG 1.1//EN"
+       "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3300 2200">
+ <!--glyph: "10193B", point size: 100.0, font version: "20.0d10e1", template writer version: "138.0.0"-->
+ <style>.defaults {-sfsymbols-wiggle-style:linear;-sfsymbols-wiggle-angle:0}
+
+.monochrome-0 {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.monochrome-1 {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.monochrome-2 {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.monochrome-3 {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+
+.multicolor-0:tintColor {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.multicolor-1:tintColor {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.multicolor-2:tintColor {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.multicolor-3:tintColor {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+
+.hierarchical-0:secondary {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.hierarchical-1:primary {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.hierarchical-2:primary {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+.hierarchical-3:primary {-sfsymbols-motion-group:0;-sfsymbols-layer-tags:arrow.right.page.on.clipboard}
+
+.SFSymbolsPreviewWireframe {fill:none;opacity:1.0;stroke:black;stroke-width:0.5}
+</style>
+ <g id="Notes">
+  <rect height="2200" id="artboard" style="fill:white;opacity:1" width="3300" x="0" y="0"/>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="292" y2="292"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 322)">Weight/Scale Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 559.711 322)">Ultralight</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 856.422 322)">Thin</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1153.13 322)">Light</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1449.84 322)">Regular</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1746.56 322)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2043.27 322)">Semibold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2339.98 322)">Bold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2636.69 322)">Heavy</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2933.4 322)">Black</text>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1903" y2="1903"/>
+  <g transform="matrix(0.2 0 0 0.2 263 1933)">
+   <path d="m46.2402 4.15039c21.7773 0 39.4531-17.627 39.4531-39.4043s-17.6758-39.4043-39.4531-39.4043c-21.7285 0-39.4043 17.627-39.4043 39.4043s17.6758 39.4043 39.4043 39.4043Zm0-7.42188c-17.6758 0-31.9336-14.3066-31.9336-31.9824s14.2578-31.9824 31.9336-31.9824 31.9824 14.3066 31.9824 31.9824-14.3066 31.9824-31.9824 31.9824Zm-17.9688-31.9824c0 2.14844 1.51367 3.61328 3.75977 3.61328h10.498v10.5957c0 2.19727 1.46484 3.71094 3.61328 3.71094 2.24609 0 3.71094-1.51367 3.71094-3.71094v-10.5957h10.5957c2.19727 0 3.71094-1.46484 3.71094-3.61328 0-2.19727-1.51367-3.71094-3.71094-3.71094h-10.5957v-10.5469c0-2.24609-1.46484-3.75977-3.71094-3.75977-2.14844 0-3.61328 1.51367-3.61328 3.75977v10.5469h-10.498c-2.24609 0-3.75977 1.51367-3.75977 3.71094Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 281.506 1933)">
+   <path d="m58.5449 14.5508c27.4902 0 49.8047-22.3145 49.8047-49.8047s-22.3145-49.8047-49.8047-49.8047-49.8047 22.3145-49.8047 49.8047 22.3145 49.8047 49.8047 49.8047Zm0-8.30078c-22.9492 0-41.5039-18.5547-41.5039-41.5039s18.5547-41.5039 41.5039-41.5039 41.5039 18.5547 41.5039 41.5039-18.5547 41.5039-41.5039 41.5039Zm-22.6562-41.5039c0 2.39258 1.66016 4.00391 4.15039 4.00391h14.3555v14.4043c0 2.44141 1.66016 4.15039 4.05273 4.15039 2.44141 0 4.15039-1.66016 4.15039-4.15039v-14.4043h14.4043c2.44141 0 4.15039-1.61133 4.15039-4.00391 0-2.44141-1.70898-4.15039-4.15039-4.15039h-14.4043v-14.3555c0-2.49023-1.70898-4.19922-4.15039-4.19922-2.39258 0-4.05273 1.70898-4.05273 4.19922v14.3555h-14.3555c-2.49023 0-4.15039 1.70898-4.15039 4.15039Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 304.924 1933)">
+   <path d="m74.8535 28.3203c35.1074 0 63.623-28.4668 63.623-63.5742s-28.5156-63.623-63.623-63.623-63.5742 28.5156-63.5742 63.623 28.4668 63.5742 63.5742 63.5742Zm0-9.08203c-30.127 0-54.4922-24.3652-54.4922-54.4922s24.3652-54.4922 54.4922-54.4922 54.4922 24.3652 54.4922 54.4922-24.3652 54.4922-54.4922 54.4922Zm-28.8574-54.4922c0 2.58789 1.85547 4.39453 4.58984 4.39453h19.7266v19.7754c0 2.68555 1.85547 4.58984 4.44336 4.58984 2.68555 0 4.54102-1.85547 4.54102-4.58984v-19.7754h19.7754c2.68555 0 4.58984-1.80664 4.58984-4.39453 0-2.73438-1.85547-4.58984-4.58984-4.58984h-19.7754v-19.7266c0-2.73438-1.85547-4.63867-4.54102-4.63867-2.58789 0-4.44336 1.9043-4.44336 4.63867v19.7266h-19.7266c-2.73438 0-4.58984 1.85547-4.58984 4.58984Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 1953)">Design Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1971)">Symbols are supported in up to nine weights and three scales.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1989)">For optimal layout with text and other symbols, vertically align</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 2007)">symbols with the adjacent text.</text>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="776" x2="776" y1="1919" y2="1933"/>
+  <g transform="matrix(0.2 0 0 0.2 776 1933)">
+   <path d="m16.5527 0.78125c2.58789 0 3.85742-0.976562 4.78516-3.71094l6.29883-17.2363h28.8086l6.29883 17.2363c0.927734 2.73438 2.19727 3.71094 4.73633 3.71094 2.58789 0 4.24805-1.5625 4.24805-4.00391 0-0.830078-0.146484-1.61133-0.537109-2.63672l-22.9004-60.9863c-1.12305-2.97852-3.125-4.49219-6.25-4.49219-3.02734 0-5.07812 1.46484-6.15234 4.44336l-22.9004 61.084c-0.390625 1.02539-0.537109 1.80664-0.537109 2.63672 0 2.44141 1.5625 3.95508 4.10156 3.95508Zm13.4766-28.3691 11.8652-32.8613h0.244141l11.8652 32.8613Z"/>
+  </g>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="792.836" x2="792.836" y1="1919" y2="1933"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 776 1953)">Margins</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1971)">Leading and trailing margins on the left and right side of each symbol</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1989)">can be adjusted by modifying the x-location of the margin guidelines.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2007)">Modifications are automatically applied proportionally to all</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2025)">scales and weights.</text>
+  <g transform="matrix(0.2 0 0 0.2 1289 1933)">
+   <path d="m14.209 9.32617 8.49609 8.54492c4.29688 4.3457 9.22852 4.05273 13.8672-1.07422l53.4668-58.9355-4.83398-4.88281-53.0762 58.3984c-1.75781 2.00195-3.41797 2.49023-5.76172 0.146484l-5.85938-5.81055c-2.34375-2.29492-1.80664-4.00391 0.195312-5.81055l57.373-54.0039-4.88281-4.83398-57.959 54.4434c-4.93164 4.58984-5.32227 9.47266-1.02539 13.8184Zm32.0801-90.9668c-2.09961 2.05078-2.24609 4.93164-1.07422 6.88477 1.17188 1.80664 3.4668 2.97852 6.68945 2.14844 7.32422-1.70898 14.9414-2.00195 22.0703 2.68555l-2.92969 7.27539c-1.70898 4.15039-0.830078 7.08008 1.85547 9.81445l11.4746 11.5723c2.44141 2.44141 4.49219 2.53906 7.32422 2.05078l5.32227-0.976562 3.32031 3.36914-0.195312 2.7832c-0.195312 2.49023 0.439453 4.39453 2.88086 6.78711l3.80859 3.71094c2.39258 2.39258 5.46875 2.53906 7.8125 0.195312l14.5508-14.5996c2.34375-2.34375 2.24609-5.32227-0.146484-7.71484l-3.85742-3.80859c-2.39258-2.39258-4.24805-3.17383-6.64062-2.97852l-2.88086 0.244141-3.22266-3.17383 1.2207-5.61523c0.634766-2.83203-0.146484-5.0293-3.07617-7.95898l-10.9863-10.9375c-16.6992-16.6016-38.8672-16.2109-53.3203-1.75781Zm7.4707 1.85547c12.1582-8.88672 28.6133-7.37305 39.7461 3.75977l12.1582 12.0605c1.17188 1.17188 1.36719 2.09961 1.02539 3.80859l-1.61133 7.42188 7.51953 7.42188 4.93164-0.292969c1.26953-0.0488281 1.66016 0.0488281 2.63672 1.02539l2.88086 2.88086-12.207 12.207-2.88086-2.88086c-0.976562-0.976562-1.12305-1.36719-1.07422-2.68555l0.341797-4.88281-7.4707-7.42188-7.61719 1.26953c-1.61133 0.341797-2.34375 0.195312-3.56445-0.976562l-10.0098-10.0098c-1.26953-1.17188-1.41602-2.00195-0.634766-3.85742l4.39453-10.4492c-7.8125-7.27539-17.9688-10.4004-28.125-7.42188-0.78125 0.195312-1.07422-0.439453-0.439453-0.976562Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 1289 1953)">Exporting</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1971)">Symbols should be outlined when exporting to ensure the</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1989)">design is preserved when submitting to Xcode.</text>
+  <text id="template-version" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1933)">Template v.6.0</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1951)">Requires Xcode 16 or greater</text>
+  <text id="descriptive-name" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1969)">Generated from arrow.right.page.on.clipboard</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1987)">Typeset at 100.0 points</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 726)">Small</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1156)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1586)">Large</text>
+ </g>
+ <g id="Guides">
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 696)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="696" y2="696"/>
+  <line id="Capline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="625.541" y2="625.541"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1126)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1126" y2="1126"/>
+  <line id="Capline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1055.54" y2="1055.54"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1556)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1556" y2="1556"/>
+  <line id="Capline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1485.54" y2="1485.54"/>
+  <line id="right-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2986.33" x2="2986.33" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2880.47" x2="2880.47" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1498.99" x2="1498.99" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1400.7" x2="1400.7" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="607.426" x2="607.426" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="511.996" x2="511.996" y1="600.785" y2="720.121"/>
+ </g>
+ <g id="Symbols">
+  <g id="Black-S" transform="matrix(1 0 0 1 2880.47 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M30.5664-71.2891L30.5664-21.3867C30.5664-11.8164 36.2305-6.15234 45.8008-6.15234L80.8594-6.15234C90.4297-6.15234 96.0938-11.8164 96.0938-21.3867L96.0938-71.2891C96.0938-80.8594 90.4297-86.5234 80.8594-86.5234L45.8008-86.5234C36.2305-86.5234 30.5664-80.8594 30.5664-71.2891ZM55.7129-69.9707C53.9062-69.9707 52.4414-71.5332 52.4414-73.2422L52.4414-74.3164C52.4414-75.4395 53.5156-77.5879 55.7129-77.5879L70.9961-77.5879C73.1934-77.5879 74.2676-75.4395 74.2676-74.3164L74.2676-73.2422C74.2676-71.5332 72.7539-69.9707 70.9961-69.9707Z"/>
+   <path class="monochrome-1 monochrome-2 multicolor-1:tintColor multicolor-2:tintColor hierarchical-1:primary hierarchical-2:primary SFSymbolsPreviewWireframe" d="M9.76562 0.878906C9.76562 10.4492 15.4297 16.1133 25 16.1133L60.0586 16.1133C69.6289 16.1133 75.293 10.4492 75.293 0.878906L75.293-49.0234C75.293-58.5938 69.6289-64.2578 60.0586-64.2578L25-64.2578C15.4297-64.2578 9.76562-58.5938 9.76562-49.0234Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:primary SFSymbolsPreviewWireframe" d="M23.9258-1.36719L23.9258-46.7773C23.9258-49.0234 24.8047-50.0977 27.2461-50.0977L57.8125-50.0977C60.2539-50.0977 61.1328-49.0234 61.1328-46.7773L61.1328-1.36719C61.1328 0.878906 60.2539 1.95312 57.8125 1.95312L27.2461 1.95312C24.8047 1.95312 23.9258 0.878906 23.9258-1.36719Z"/>
+   <path class="monochrome-3 multicolor-3:tintColor hierarchical-3:primary SFSymbolsPreviewWireframe" d="M58.0566-24.0723C58.0566-25.3418 57.6172-26.6602 56.4453-27.9297L47.2656-37.5C46.5332-38.2324 45.752-38.6719 44.5801-38.6719C42.3828-38.6719 40.8691-36.6699 40.8691-34.8145C40.8691-33.5938 41.4062-32.6172 42.1875-31.8848L44.8242-29.3457L47.4121-28.2715L43.1641-28.7109L31.5918-28.7109C29.1016-28.7109 27.002-26.6602 27.002-24.0723C27.002-21.4355 29.1016-19.4336 31.5918-19.4336L43.1641-19.4336L47.4121-19.873L44.8242-18.7988L42.1875-16.2598C41.4062-15.5273 40.8691-14.5508 40.8691-13.3301C40.8691-11.4746 42.3828-9.47266 44.5801-9.47266C45.752-9.47266 46.5332-9.91211 47.2656-10.6445L56.4453-20.2148C57.6172-21.4844 58.0566-22.8027 58.0566-24.0723Z"/>
+  </g>
+  <g id="Regular-S" transform="matrix(1 0 0 1 1400.7 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M28.3203-71.2891L28.3203-18.75C28.3203-10.4492 32.373-6.29883 40.5762-6.29883L76.2207-6.29883C84.4238-6.29883 88.5254-10.4492 88.5254-18.75L88.5254-71.2891C88.5254-79.6387 84.4238-83.7402 76.2207-83.7402L40.5762-83.7402C32.373-83.7402 28.3203-79.6387 28.3203-71.2891ZM48.8281-70.1172C47.0703-70.1172 46.2402-71.2891 46.2402-72.5098L46.2402-73.3887C46.2402-74.6094 47.0703-75.7812 48.8281-75.7812L68.0176-75.7812C69.7754-75.7812 70.6055-74.6094 70.6055-73.3887L70.6055-72.5098C70.6055-71.2891 69.7754-70.1172 68.0176-70.1172Z"/>
+   <path class="monochrome-1 monochrome-2 multicolor-1:tintColor multicolor-2:tintColor hierarchical-1:primary hierarchical-2:primary SFSymbolsPreviewWireframe" d="M9.76562 0.683594C9.76562 9.0332 13.8184 13.1348 22.0215 13.1348L57.666 13.1348C65.8691 13.1348 69.9707 8.98438 69.9707 0.683594L69.9707-51.8555C69.9707-60.1562 65.8691-64.3066 57.666-64.3066L22.0215-64.3066C13.8184-64.3066 9.76562-60.2051 9.76562-51.8555Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:primary SFSymbolsPreviewWireframe" d="M16.7969 0.585938L16.7969-51.7578C16.7969-55.2734 18.7012-57.2754 22.3633-57.2754L57.3242-57.2754C60.9863-57.2754 62.8906-55.2734 62.8906-51.7578L62.8906 0.585938C62.8906 4.10156 60.9863 6.10352 57.3242 6.10352L22.3633 6.10352C18.7012 6.10352 16.7969 4.10156 16.7969 0.585938Z"/>
+   <path class="monochrome-3 multicolor-3:tintColor hierarchical-3:primary SFSymbolsPreviewWireframe" d="M55.957-25.5859C55.957-26.3184 55.6641-27.0508 54.9316-27.832L45.166-38.0371C44.6289-38.623 43.9941-38.9648 43.1152-38.9648C41.5527-38.9648 40.332-37.7441 40.332-36.1328C40.332-35.4004 40.6738-34.5703 41.3086-33.9844L46.0938-29.6387L47.2656-28.5156L43.2129-28.7109L26.7578-28.7109C25.1465-28.7109 23.7305-27.2461 23.7305-25.5859C23.7305-23.9258 25.1465-22.4609 26.7578-22.4609L43.2129-22.4609L47.2656-22.6562L46.0938-21.5332L41.3086-17.1875C40.6738-16.6016 40.332-15.8203 40.332-15.0879C40.332-13.4766 41.5527-12.207 43.1152-12.207C43.9941-12.207 44.6289-12.5977 45.166-13.1348L54.9316-23.3398C55.6641-24.1211 55.957-24.8535 55.957-25.5859Z"/>
+  </g>
+  <g id="Ultralight-S" transform="matrix(1 0 0 1 511.996 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M28.2749-71.9248L28.2749-16.1616C28.2749-9.63184 31.7373-6.1626 38.2603-6.1626L75.6758-6.1626C82.1987-6.1626 85.6646-9.63184 85.6646-16.1616L85.6646-71.9248C85.6646-78.458 82.1987-81.9238 75.6758-81.9238L38.2603-81.9238C31.7373-81.9238 28.2749-78.458 28.2749-71.9248ZM48.7827-71.0708C47.5698-71.0708 46.9668-71.8794 46.9668-72.6914L46.9668-73.2979C46.9668-74.1099 47.5698-74.9185 48.7827-74.9185L65.1568-74.9185C66.3242-74.9185 66.9273-74.1099 66.9273-73.2979L66.9273-72.6914C66.9273-71.8794 66.3242-71.0708 65.1568-71.0708Z"/>
+   <path class="monochrome-1 monochrome-2 multicolor-1:tintColor multicolor-2:tintColor hierarchical-1:primary hierarchical-2:primary SFSymbolsPreviewWireframe" d="M9.76562 1.41015C9.76562 7.94337 13.228 11.4092 19.751 11.4092L57.1665 11.4092C63.6895 11.4092 67.1553 7.98536 67.1553 1.41015L67.1553-54.353C67.1553-60.8828 63.6895-64.3521 57.1665-64.3521L19.751-64.3521C13.228-64.3521 9.76562-60.8862 9.76562-54.353Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:primary SFSymbolsPreviewWireframe" d="M11.9834 1.31249L11.9834-54.2554C11.9834-59.4511 14.6597-62.1342 19.8657-62.1342L57.0518-62.1342C62.2578-62.1342 64.9341-59.4511 64.9341-54.2554L64.9341 1.31249C64.9341 6.50828 62.2578 9.19138 57.0518 9.19138L19.8657 9.19138C14.6597 9.19138 11.9834 6.50828 11.9834 1.31249Z"/>
+   <path class="monochrome-3 multicolor-3:tintColor hierarchical-3:primary SFSymbolsPreviewWireframe" d="M55.2759-26.4487C55.2759-26.727 55.1646-27.0054 54.9771-27.2417L43.3042-38.8545C43.085-39.1226 42.8135-39.1919 42.6157-39.1919C42.0522-39.1919 41.5581-38.7432 41.5581-38.2217C41.5581-37.9887 41.6728-37.6128 41.9443-37.4355L49.0454-30.3652L51.8974-27.5166L47.436-27.5303L22.7163-27.5303C22.1494-27.5303 21.6416-27.0645 21.6416-26.4487C21.6416-25.8784 22.1494-25.3672 22.7163-25.3672L47.436-25.3672L51.852-25.4262L49.0454-22.623L41.9443-15.5527C41.6728-15.3301 41.5581-15.0029 41.5581-14.77C41.5581-14.2485 42.0522-13.7964 42.6157-13.7964C42.8135-13.7964 43.085-13.8691 43.3042-14.0884L54.9771-25.7012C55.1646-25.9375 55.2759-26.2612 55.2759-26.4487Z"/>
+  </g>
+ </g>
+</svg>

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Services/Clipboard Sharing/ClipboardSharing.h
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Services/Clipboard Sharing/ClipboardSharing.h
@@ -1,0 +1,16 @@
+//
+//  ClipboardSharing.h
+//  PocketShaver
+//
+//  Created by Carl Björkman on 2026-07-19.
+//
+
+#ifdef __cplusplus
+extern "C"
+#endif
+void objc_copyHostClipboardToGuestScrap();
+
+#ifdef __cplusplus
+extern "C"
+#endif
+void objc_copyGuestScrapToHostClipboard();

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Services/Clipboard Sharing/ClipboardSharing.mm
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Services/Clipboard Sharing/ClipboardSharing.mm
@@ -1,0 +1,17 @@
+//
+//  ClipboardSharing.mm
+//  PocketShaver
+//
+//  Created by Carl Björkman on 2026-07-19.
+//
+
+#import "utils_ios.h"
+#import "ClipboardSharing.h"
+
+void objc_copyHostClipboardToGuestScrap() {
+	SyncHostPasteboardToPending();
+}
+
+void objc_copyGuestScrapToHostClipboard() {
+	WritePendingGuestScrapToHostPasteboard();
+}

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Services/Clipboard Sharing/clip_ios.mm
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Services/Clipboard Sharing/clip_ios.mm
@@ -35,6 +35,10 @@
 #include "autorelease.h"
 #include "pict.h"
 
+#include "utils_ios.h"
+#include "MiscellaneousSettingsObjCCppHeader.h"
+#import "PocketShaver-Swift-ObjCHeader.h"
+
 #define DEBUG 0
 #include "debug.h"
 
@@ -127,6 +131,9 @@ static NSString *g_pending_host_text = nil;								// fallback, plain text
 static NSData *g_pending_host_pict = nil;								// raw PICT from the host, if any
 static UIImage *g_pending_host_image = nil;								// host image to convert to PICT
 static NSDictionary<NSNumber *, NSData *> *g_pending_host_flavors = nil;	// other flavors, keyed by FourCC
+
+// Guest scrap content waiting to be copied to host pasteboard
+static NSMutableDictionary<NSString *, id> *g_pending_guest_scrap;
 
 // UIPasteboard change count at our last read or write. Main thread only.
 // Advisory only: unreliable on Catalyst, so it never gates correctness there.
@@ -1527,14 +1534,42 @@ static NSData *PNGDataFromPICT(NSData *pictData)
 	return (wrote && [pngData length]) ? pngData : nil;
 }
 
+void WritePendingGuestScrapToHostPasteboard(void) {
+	if (!g_pending_guest_scrap) {
+		[LocalNotificationObjCProxy sendClipboardSharingGuestToHostWithContent:ClipboardSharingContentEmpty];
+		return;
+	}
+
+	if ([g_pending_guest_scrap objectForKey:kPasteboardTypePNG]) {
+		[LocalNotificationObjCProxy sendClipboardSharingGuestToHostWithContent:ClipboardSharingContentImage];
+	} else {
+		[LocalNotificationObjCProxy sendClipboardSharingGuestToHostWithContent:ClipboardSharingContentText];
+	}
+
+	UIPasteboard *pb = [UIPasteboard generalPasteboard];
+
+	g_last_stash_signature = nil;
+
+	[pb setItems:@[g_pending_guest_scrap] options:@{}];
+
+	g_host_change_count = [pb changeCount];
+	os_unfair_lock_lock(&g_pending_lock);
+	g_pending_host_attr = nil;
+	g_pending_host_text = nil;
+	g_pending_host_pict = nil;
+	g_pending_host_image = nil;
+	g_pending_host_flavors = nil;
+	os_unfair_lock_unlock(&g_pending_lock);
+}
+
 /*
  *  Convert the guest scrap flavors collected so far to host pasteboard content.
  *  Called on the emulator thread; the pasteboard write happens on the main thread.
  */
 
-static void WriteGuestScrapToHostPasteboard(void)
+static void SyncGuestScrapToPending(void)
 {
-	NSMutableDictionary<NSString *, id> *item = [NSMutableDictionary dictionary];
+	g_pending_guest_scrap = [NSMutableDictionary dictionary];
 
 	// TEXT (+ styl) become plain text and RTF
 	NSData *textData = [g_guest_scrap objectForKey:@(TYPE_TEXT)];
@@ -1571,9 +1606,9 @@ static void WriteGuestScrapToHostPasteboard(void)
 		}
 
 		if ([plain length]) {
-			[item setObject:plain forKey:kPasteboardTypeUTF8];
+			[g_pending_guest_scrap setObject:plain forKey:kPasteboardTypeUTF8];
 			if (rtfData)
-				[item setObject:rtfData forKey:kPasteboardTypeRTF];
+				[g_pending_guest_scrap setObject:rtfData forKey:kPasteboardTypeRTF];
 		}
 	}
 
@@ -1588,8 +1623,9 @@ static void WriteGuestScrapToHostPasteboard(void)
 			pngData = nil;
 		}
 		if (pngData)
-			[item setObject:pngData forKey:kPasteboardTypePNG];
+			[g_pending_guest_scrap setObject:pngData forKey:kPasteboardTypePNG];
 	}
+
 
 	// Everything else (PICT included) passes through under a mapped type string.
 	// utxt/ustl pass through together so Unicode-savvy guest apps keep styles
@@ -1601,18 +1637,18 @@ static void WriteGuestScrapToHostPasteboard(void)
 		if (type == TYPE_TEXT || type == TYPE_STYL)
 			continue;
 
-		[item setObject:[g_guest_scrap objectForKey:key] forKey:UTIForFlavor(type)];
+		[g_pending_guest_scrap setObject:[g_guest_scrap objectForKey:key] forKey:UTIForFlavor(type)];
 	}
 
-	if (![item count]) {
+	if (![g_pending_guest_scrap count]) {
 		CLIP_LOG("publish: nothing to publish yet (guest flavors: %{public}@)", [[g_guest_scrap allKeys] description]);
 		return;
 	}
 
 	NSString *publishUUID = [[NSUUID UUID] UUIDString];
-	[item setObject:publishUUID forKey:kPasteboardTypeMarker];
+	[g_pending_guest_scrap setObject:publishUUID forKey:kPasteboardTypeMarker];
 
-	CLIP_LOG("publish -> host: %{public}@", [[item allKeys] componentsJoinedByString:@", "]);
+	CLIP_LOG("publish -> host: %{public}@", [[g_pending_guest_scrap allKeys] componentsJoinedByString:@", "]);
 
 	// The guest's copy supersedes any host content still waiting to be injected
 	os_unfair_lock_lock(&g_pending_lock);
@@ -1623,25 +1659,15 @@ static void WriteGuestScrapToHostPasteboard(void)
 	g_pending_host_flavors = nil;
 	os_unfair_lock_unlock(&g_pending_lock);
 
-	dispatch_async(dispatch_get_main_queue(), ^{
-		UIPasteboard *pb = [UIPasteboard generalPasteboard];
+	if (objc_getIsClipboardSharingAutomatic()) {
+		dispatch_async(dispatch_get_main_queue(), ^{
+			// The marker (not changeCount, which is unreliable on Catalyst) is what
+			// keeps this write from being bounced back into the guest
+			g_last_published_uuid = publishUUID;
 
-		// The marker (not changeCount, which is unreliable on Catalyst) is what
-		// keeps this write from being bounced back into the guest
-		g_last_published_uuid = publishUUID;
-		g_last_stash_signature = nil;
-
-		[pb setItems:@[item] options:@{}];
-
-		g_host_change_count = [pb changeCount];
-		os_unfair_lock_lock(&g_pending_lock);
-		g_pending_host_attr = nil;
-		g_pending_host_text = nil;
-		g_pending_host_pict = nil;
-		g_pending_host_image = nil;
-		g_pending_host_flavors = nil;
-		os_unfair_lock_unlock(&g_pending_lock);
-	});
+			WritePendingGuestScrapToHostPasteboard();
+		});
+	}
 }
 
 /*
@@ -1650,15 +1676,19 @@ static void WriteGuestScrapToHostPasteboard(void)
  *  Main thread only.
  */
 
-static void SyncHostPasteboardToPending(void)
+void SyncHostPasteboardToPending(void)
 {
 	UIPasteboard *pb = [UIPasteboard generalPasteboard];
 
 #if !TARGET_OS_MACCATALYST
 	// changeCount is only trustworthy on iOS; on Catalyst it changes between
 	// reads, so there the marker and content signature below do the gating
-	if ([pb changeCount] == g_host_change_count)
+	if ([pb changeCount] == g_host_change_count) {
+		if (!objc_getIsClipboardSharingAutomatic()) {
+			[LocalNotificationObjCProxy sendClipboardSharingHostToGuestWithContent:ClipboardSharingContentAlreadyCopied];
+		}
 		return;
+	}
 #endif
 	g_host_change_count = [pb changeCount];
 
@@ -1675,6 +1705,9 @@ static void SyncHostPasteboardToPending(void)
 
 		if (markerString && [markerString isEqualToString:g_last_published_uuid]) {
 			CLIP_LOG("sync: own content (marker match), skipping");
+			if (!objc_getIsClipboardSharingAutomatic()) {
+				[LocalNotificationObjCProxy sendClipboardSharingHostToGuestWithContent:ClipboardSharingContentAlreadyCopied];
+			}
 			return;
 		}
 	}
@@ -1795,6 +1828,14 @@ static void SyncHostPasteboardToPending(void)
 	g_pending_host_image = image;
 	g_pending_host_flavors = ([flavors count] ? [flavors copy] : nil);
 	os_unfair_lock_unlock(&g_pending_lock);
+
+	if (g_pending_host_pict || g_pending_host_image) {
+		[LocalNotificationObjCProxy sendClipboardSharingHostToGuestWithContent:ClipboardSharingContentImage];
+	} else if (g_pending_host_attr || g_pending_host_text || g_pending_host_flavors) {
+		[LocalNotificationObjCProxy sendClipboardSharingHostToGuestWithContent:ClipboardSharingContentText];
+	} else {
+		[LocalNotificationObjCProxy sendClipboardSharingHostToGuestWithContent:ClipboardSharingContentEmpty];
+	}
 }
 
 /*
@@ -1817,7 +1858,9 @@ void ClipInit(void)
 	dispatch_async(dispatch_get_main_queue(), ^{
 		NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
 		void (^sync)(NSNotification *) = ^(NSNotification *notification) {
-			RequestHostPasteboardSync();
+			if (objc_getIsClipboardSharingAutomatic()) {
+				RequestHostPasteboardSync();
+			}
 		};
 		g_pasteboard_observers[0] = [nc addObserverForName:UIApplicationDidBecomeActiveNotification
 													object:nil
@@ -1832,7 +1875,9 @@ void ClipInit(void)
 													object:nil
 													 queue:[NSOperationQueue mainQueue]
 												usingBlock:sync];
-		RequestHostPasteboardSync();
+		if (objc_getIsClipboardSharingAutomatic()) {
+			RequestHostPasteboardSync();
+		}
 	});
 }
 
@@ -1884,7 +1929,7 @@ void GetScrap(void **handle, uint32 type, int32 offset)
 	g_pending_host_flavors = nil;
 	os_unfair_lock_unlock(&g_pending_lock);
 
-	if (!attr && !text && !pictData && !image && ![flavors count]) {
+	if (!attr && !text && !pictData && !image && ![flavors count] && objc_getIsClipboardSharingAutomatic()) {
 		// Fallback for missed activation notifications: refresh the pending
 		// slots so the next GetScrap sees current host content
 		static double last_refresh = 0;		// emulator thread only
@@ -2025,7 +2070,7 @@ void PutScrap(uint32 type, void *scrap, int32 length)
 
 		// Never let a conversion failure raise through the EMUL_OP into the emulator
 		@try {
-			WriteGuestScrapToHostPasteboard();
+			SyncGuestScrapToPending();
 		} @catch (NSException *exception) {
 			CLIP_LOG("PutScrap conversion raised: %{public}@", exception);
 		}

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Services/Gamepad/GamepadManager.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Services/Gamepad/GamepadManager.swift
@@ -138,12 +138,12 @@ class GamepadConfig: Codable {
 			)
 			if let secondIndex = sideButtonMappings.firstIndex(where: { $0.position == secondIndexPosition }),
 			   sideButtonMappings.firstIndex(where: { $0.position == firstIndexPosition }) == nil {
-				let assigment = sideButtonMappings[secondIndex].assignment
+				let assignment = sideButtonMappings[secondIndex].assignment
 				removeAssignment(at: secondIndexPosition)
 
 				let newMapping = GamepadSideButtonMapping(
 					position: firstIndexPosition,
-					assignment: assigment
+					assignment: assignment
 				)
 				self.sideButtonMappings!.append(newMapping)
 

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Utils/Extensions/Extensions.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Utils/Extensions/Extensions.swift
@@ -112,6 +112,14 @@ enum DeviceType {
 	case iPhone
 	case iPad
 	case mac
+
+	var osLabel: String {
+		switch self {
+		case .iPhone: "iOS"
+		case .iPad: "iPadOS"
+		case .mac: "macOS"
+		}
+	}
 }
 
 extension UIDevice {

--- a/SheepShaver/src/MacOSX/PocketShaver/Swift/Utils/Local notification/LocalNotification.swift
+++ b/SheepShaver/src/MacOSX/PocketShaver/Swift/Utils/Local notification/LocalNotification.swift
@@ -20,6 +20,9 @@ enum LocalNotification: String {
 	case displayPreferencesRequested
 	case enteredKeyboardModeWhileUsingHardwareKeyboard
 	case catalystFullscreenStateChanged
+	case clipboardSharingSettingChanged
+	case clipboardSharingGuestToHost
+	case clipboardSharingHostToGuest
 
 	static func send(_ notification: LocalNotification, object: Any? = nil) {
 		NotificationCenter.default.post(
@@ -66,4 +69,20 @@ class LocalNotificationObjCProxy: NSObject {
 	static func sendCatalystFullscreenStateChanged() {
 		LocalNotification.send(.catalystFullscreenStateChanged)
 	}
+
+	static func sendClipboardSharingGuestToHost(content: ClipboardSharingContent) {
+		LocalNotification.send(.clipboardSharingGuestToHost, object: content)
+	}
+
+	static func sendClipboardSharingHostToGuest(content: ClipboardSharingContent) {
+		LocalNotification.send(.clipboardSharingHostToGuest, object: content)
+	}
+}
+
+@objc
+enum ClipboardSharingContent: Int {
+	case text
+	case image
+	case alreadyCopied
+	case empty
 }

--- a/SheepShaver/src/MacOSX/PocketShaver/utils_ios.h
+++ b/SheepShaver/src/MacOSX/PocketShaver/utils_ios.h
@@ -63,5 +63,7 @@ extern void set_relative_mouse_automatic();
 extern void report_relative_mouse_capability();
 extern void setup_frame_rate();
 extern void set_input_disabled(bool is_disabled);
+extern void SyncHostPasteboardToPending(void);
+extern void WritePendingGuestScrapToHostPasteboard(void);
 
 #endif

--- a/SheepShaver/src/MacOSX/Supporting files/PocketShaver-Bridging-Header.h
+++ b/SheepShaver/src/MacOSX/Supporting files/PocketShaver-Bridging-Header.h
@@ -14,6 +14,7 @@
 #import "MouseHapticFeedbackObjC.h"
 #import "BonjourManagerObjC.h"
 #import "ImpHFSExtractor.h"
+#import "ClipboardSharing.h"
 
 // Memory-warning C shim + PSO archive C API +
 // background/foreground lifecycle handlers.

--- a/SheepShaver/src/prefs_items.cpp
+++ b/SheepShaver/src/prefs_items.cpp
@@ -119,10 +119,10 @@ void AddPrefsDefaults(void)
 	PrefsAddInt32("frameskip", 8);
 #endif
 	PrefsAddBool("gfxaccel", true);
-	PrefsAddBool("nqdaccel", true);
-	PrefsAddBool("raveaccel", true);
-	PrefsAddBool("glaccel", true);
-	PrefsAddBool("dspaccel", true);
+	PrefsAddBool("nqdaccel", false);
+	PrefsAddBool("raveaccel", false);
+	PrefsAddBool("glaccel", false);
+	PrefsAddBool("dspaccel", false);
 	PrefsAddBool("nocdrom", false);
 	PrefsAddBool("nonet", false);
 	PrefsAddBool("nosound", false);


### PR DESCRIPTION
- Added a small system for handling clipboard sharing. On iOS / iPadOS, a dialogue appears saying "Allow paste from {source}" each time the clipboard is read. Therefore added control to the user to decide when the copy between the clipboards happpens as well as retained the possibility of the original system. On Mac, the "automatic sharing" is default on, whereas on iOS / iPadOS, manual control is default. Also added a small (optional) message for when the clipboard sharing happens. (Side note: Had to painstakingly create the asset for the clipboard with a left arrow myself by editing the SVG path, since only the right arrow variant existed in SF Symbols 😁).
- Fix for removing the empty area above the action bar in General tab as well as the other tabs. The fix is a bit "conservative", but I think it is the best approach to save more UITableView headaches 🙂 
- Small UX refactoring in the preferences tabs. Copy changes etc.